### PR TITLE
Allowing users to also pass virtual fields to the scaffold views

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -283,8 +283,7 @@ class ViewListener extends BaseListener
         $action = $this->_action();
         $configuredFields = $action->config('scaffold.fields');
         if (!empty($configuredFields)) {
-            $configuredFields = Hash::normalize($configuredFields);
-            $scaffoldFields = array_intersect_key($configuredFields, $scaffoldFields);
+            $scaffoldFields = Hash::normalize($configuredFields);
         }
 
         // Check for blacklisted fields


### PR DESCRIPTION
I see no reason for limiting the users to just the fields in the schema