### PR TITLE
Make datetime picker configurable

### DIFF
--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -12,6 +12,14 @@ jQuery(document).on('ready', function() {
     });
   }
 
+  jQuery('[role=datetime-picker]').each(function() {
+    $(this).datetimepicker({
+      locale: $(this).data('locale'),
+      format: $(this).data('format'),
+      date: new Date($(this).data('timestamp') * 1000)
+    });
+  });
+
   jQuery('input.autocomplete').each(function () {
     var _this = jQuery(this);
     var cache = {};


### PR DESCRIPTION
This moves the JS to `local.js` and allows for more configuration (format / locale) to be passed to the widget (and picker's JS) using `data-*`.

/cc @lorenzo @ADmad