### PR TITLE
Actions

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -294,13 +294,14 @@ class ViewListener extends BaseListener
             $action = $this->_action($actionName);
             $method = 'GET';
             $class = get_class($action);
+            $class = substr($class, strrpos($class, '\\') + 1);
             $scope = $action->scope();
 
-            if ($class === 'Crud\Action\DeleteAction') {
+            if ($class === 'DeleteAction') {
                 $method = 'DELETE';
             }
 
-            if ($class === 'Crud\Action\AddAction') {
+            if ($class === 'AddAction') {
                 $scope = 'table';
             }
 

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -308,13 +308,17 @@ class ViewListener extends BaseListener
             if ($scope === 'table') {
                 $table[$actionName] = [
                     'title' => Inflector::humanize($actionName),
-                    'controller' => $this->_request()->params['controller'],
+                    'url' => [
+                        'action' => $actionName
+                    ],
                     'method' => $method,
                 ];
             } elseif ($scope === 'entity') {
                 $entity[$actionName] = [
                     'title' => Inflector::humanize($actionName),
-                    'controller' => $this->_request()->params['controller'],
+                    'url' => [
+                        'action' => $actionName
+                    ],
                     'method' => $method,
                 ];
             }

--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -28,19 +28,13 @@ foreach ($actions as $config) {
     if (!empty($config['callback'])) {
         $callback = $config['callback'];
         unset($config['callback']);
-        $config['linkOptions'] = $linkOptions;
+        $config['options'] = $linkOptions;
         echo $callback($config, !empty($singularVar) ? $singularVar : null);
     }
 
     $url = $config['url'];
     if (!empty($singularVar)) {
-        if (!empty($config['map'])) {
-            foreach ($config['map'] as $key => $prop) {
-                $url[$key] = $singularVar[$prop];
-            }
-        } else {
-            $url[] = $singularVar->{$primaryKey};
-        }
+        $url[] = $singularVar->{$primaryKey};
     }
 
     if ($config['method'] !== 'GET') {

--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -3,10 +3,27 @@ foreach ($actions as $config) {
     $config += ['method' => 'GET'];
 
     if ((empty($config['url']['controller']) ||
-        $this->request->controller === $config['url']['controller']) &&
+            $this->request->controller === $config['url']['controller']) &&
         $this->request->action === $config['url']['action']
     ) {
         continue;
+    }
+
+    $linkOptions = ['class' => 'btn btn-default'];
+    if (isset($config['options'])) {
+        $linkOptions = $config['options'] + $linkOptions;
+    }
+
+    if ($config['method'] === 'DELETE') {
+        $linkOptions += [
+            'confirm' => __d('crud', 'Are you sure you want to delete record #{0}?', [$singularVar->{$primaryKey}])
+        ];
+    }
+
+    if ($config['method'] !== 'GET') {
+        $linkOptions += [
+            'method' => $config['method']
+        ];
     }
 
     $url = $config['url'];
@@ -20,20 +37,11 @@ foreach ($actions as $config) {
         }
     }
 
-    $options = ['class' => 'btn btn-default'];
-    if (isset($config['options'])) {
-        $options = $config['options'] + $options;
-    }
-
     if ($config['method'] !== 'GET') {
-        $options += [
-            'confirm' => __d('crud', 'Are you sure you want to delete record #{0}?', [$singularVar->{$primaryKey}]),
-            'method' => $config['method']
-        ];
         echo $this->Form->postLink(
             $config['title'],
             $url,
-            $options
+            $linkOptions
         );
         continue;
     }
@@ -41,7 +49,6 @@ foreach ($actions as $config) {
     echo $this->Html->link(
         $config['title'],
         $url,
-        $options
+        $linkOptions
     );
-
 }

--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -1,27 +1,47 @@
 <?php
-foreach ($actions as $action => $config) {
-    if ($this->request->action === $action) {
+foreach ($actions as $config) {
+    $config += ['method' => 'GET'];
+
+    if ((empty($config['url']['controller']) ||
+        $this->request->controller === $config['url']['controller']) &&
+        $this->request->action === $config['url']['action']
+    ) {
         continue;
     }
 
-    $link = ['controller' => $config['controller'], 'action' => $action];
+    $url = $config['url'];
     if (!empty($singularVar)) {
-        $link = ['controller' => $config['controller'], 'action' => $action, $singularVar->id];
+        if (!empty($config['map'])) {
+            foreach ($config['map'] as $key => $prop) {
+                $url[$key] = $singularVar[$prop];
+            }
+        } else {
+            $url[] = $singularVar->{$primaryKey};
+        }
+    }
+
+    $options = ['class' => 'btn btn-default'];
+    if (isset($config['options'])) {
+        $options = $config['options'] + $options;
     }
 
     if ($config['method'] !== 'GET') {
+        $options += [
+            'confirm' => __d('crud', 'Are you sure you want to delete record #{0}?', [$singularVar->{$primaryKey}]),
+            'method' => $config['method']
+        ];
         echo $this->Form->postLink(
             $config['title'],
-            $link,
-            ['class' => 'btn btn-default', 'method' => $config['method']]
+            $url,
+            $options
         );
         continue;
     }
 
     echo $this->Html->link(
         $config['title'],
-        $link,
-        ['class' => 'btn btn-default']
+        $url,
+        $options
     );
 
 }

--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -2,9 +2,8 @@
 foreach ($actions as $config) {
     $config += ['method' => 'GET'];
 
-    if ((empty($config['url']['controller']) ||
-            $this->request->controller === $config['url']['controller']) &&
-        $this->request->action === $config['url']['action']
+    if ((empty($config['url']['controller']) || $this->request->controller === $config['url']['controller']) &&
+        (!empty($config['url']['action']) && $this->request->action === $config['url']['action'])
     ) {
         continue;
     }
@@ -24,6 +23,13 @@ foreach ($actions as $config) {
         $linkOptions += [
             'method' => $config['method']
         ];
+    }
+
+    if (!empty($config['callback'])) {
+        $callback = $config['callback'];
+        unset($config['callback']);
+        $config['linkOptions'] = $linkOptions;
+        echo $callback($config, !empty($singularVar) ? $singularVar : null);
     }
 
     $url = $config['url'];


### PR DESCRIPTION
-  Used unqualified class name for action name comparison.

   This allows the guessing to work even for actions extending crud action.

-  Made actions links generation more flexible.

   You can now generate action link with title "Custom" and url
    like `['controller' => 'Foo', 'action' => 'index', 'slug' => <name>, <id>]` using array:
```php
    [
        'title' => 'Custom',
        'url' => ['controller' => 'Foo', 'action' => 'index'],
        'map' => ['slug' => 'name', 'id'] //id & name are entity properties whose values are used
    ]
```

Tested in a demo app :)