### PR TITLE
Fixed bug in CrudViewHelper::formatTime function

### DIFF
--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -185,7 +185,8 @@ class CrudViewHelper extends Helper
         if ($value === null) {
             return $this->Html->label(__d('crud', 'N/A'), 'info');
         }
-        return $this->Time->nice($value, $options);
+        $format = isset($options['format']) ? $options['format'] : null;
+        return $this->Time->nice($value, $format);
     }
 
     /**


### PR DESCRIPTION
Cake's Time::nice() expects the second parameter to be a string or null (not an array).
http://api.cakephp.org/3.0/class-Cake.I18n.Time.html#_nice