### PR TITLE
Added extraButtonsBlacklist feature.

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -65,6 +65,7 @@ class ViewListener extends BaseListener
         $controller->set('viewblocks', $this->_getViewBlocks());
         $controller->set('formUrl', $this->_getFormUrl());
         $controller->set('disableExtraButtons', $this->_getDisableExtraButtons());
+        $controller->set('extraButtonsBlacklist', $this->_getExtraButtonsBlacklist());
         $controller->set($this->_getPageVariables());
     }
 
@@ -473,5 +474,16 @@ class ViewListener extends BaseListener
     {
         $action = $this->_action();
         return $action->config('scaffold.disable_extra_buttons') ?: false;
+    }
+
+    /**
+     * Get extra buttons blacklist
+     *
+     * @return array
+     */
+    protected function _getExtraButtonsBlacklist()
+    {
+        $action = $this->_action();
+        return $action->config('scaffold.extra_buttons_blacklist') ?: [];
     }
 }

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -23,9 +23,15 @@
                     <?php
                         echo $this->Form->submit(__d('crud', 'Save'), ['class' => 'btn btn-primary', 'div' => false, 'name' => '_save']);
                         if (empty($disableExtraButtons)) {
-                            echo $this->Form->submit(__d('crud', 'Save & continue editing'), ['class' => 'btn btn-success btn-save-continue', 'div' => false, 'name' => '_edit']);
-                            echo $this->Form->submit(__d('crud', 'Save & create new'), ['class' => 'btn btn-success', 'div' => false, 'name' => '_add']);
-                            echo $this->Html->link(__d('crud', 'Back'), ['action' => 'index'], ['class' => 'btn btn-default', 'div' => false]);
+                            if (!in_array('save_and_continue', $extraButtonsBlacklist)) {
+                                echo $this->Form->submit(__d('crud', 'Save & continue editing'), ['class' => 'btn btn-success btn-save-continue', 'div' => false, 'name' => '_edit']);
+                            }
+                            if (!in_array('save_and_create', $extraButtonsBlacklist)) {
+                                echo $this->Form->submit(__d('crud', 'Save & create new'), ['class' => 'btn btn-success', 'div' => false, 'name' => '_add']);
+                            }
+                            if (!in_array('back', $extraButtonsBlacklist)) {
+                                echo $this->Html->link(__d('crud', 'Back'), ['action' => 'index'], ['class' => 'btn btn-default', 'div' => false]);
+                            }
                         }
                     ?>
                 </div>


### PR DESCRIPTION
More advanced "extra buttons" management for edit view.
Besides "disable all" now it's possible to specify which exactly buttons have to be disabled.

Usage:
```
        $action = $this->Crud->action();
 
        if ($this->request->action === 'edit') {
            $action->config('scaffold.extra_buttons_blacklist', [
                'save_and_continue', 'save_and_create', 'back'
            ]);
        }
```

P.S. Does it make sense to have `disableExtraButtons` option if more advanced option is available?
