### PR TITLE
Remove phpunit from "require-dev".

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "friendsofcake/bootstrap-ui": "~0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.33",
         "friendsofcake/cakephp-test-utilities": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Travis already has phpunit. We can add back specific version if the one
provided by travis causes issues in future. Locally one can just use
phpunit.phar or globally installed phpunit.

Closes #13

Currently we don't have tests anyway :)