### PR TITLE
Proposal: Invertable boolean format

### DIFF
--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -176,6 +176,9 @@ class CrudView extends View
      */
     protected function _getViewFileName($name = null)
     {
+        if ($this->viewPath === 'Error') {
+            return parent::_getViewFileName($name);
+        }
         try {
             return parent::_getViewFileName($name);
         } catch (MissingTemplateException $exception) {

--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -152,8 +152,8 @@ class CrudViewHelper extends Helper
     public function formatBoolean($field, $value, array $options)
     {
         return (bool)$value ?
-            $this->Html->label(__d('crud', 'Yes'), 'success') :
-            $this->Html->label(__d('crud', 'No'), 'danger');
+            $this->Html->label(__d('crud', 'Yes'), empty($options['inverted']) ? 'success' : 'danger') :
+            $this->Html->label(__d('crud', 'No'), empty($options['inverted']) ? 'danger' : 'success');
     }
 
     /**


### PR DESCRIPTION
Sometimes it makes sense to display "No" as success (green) and "Yes" as danger (red). 
For example fields like "is_deleted", "is_deactivated", "is_banned" etc. It would be nice to have green "No" for such situations.

Usage:
```php
// in a controller
$action = $this->Crud->action();
$fields['is_deactivated'] = ['inverted' => true];
$action->config('scaffold.fields', $fields);
```