### PR TITLE
Inverted booleans format (green No and red Yes) [rePR]

### DIFF
--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -152,13 +152,14 @@ class CrudViewHelper extends Helper
      *
      * @param string $field Name of field.
      * @param array $value Value of field.
+     * @param array $options Options array
      * @return string
      */
-    public function formatBoolean($field, $value)
+    public function formatBoolean($field, $value, $options)
     {
         return (bool)$value ?
-            $this->Html->label(__d('crud', 'Yes'), 'success') :
-            $this->Html->label(__d('crud', 'No'), 'danger');
+            $this->Html->label(__d('crud', 'Yes'), empty($options['inverted']) ? 'success' : 'danger') :
+            $this->Html->label(__d('crud', 'No'), empty($options['inverted']) ? 'danger' : 'success');
     }
 
     /**


### PR DESCRIPTION
Sometimes it makes sense to display "No" as success (green) and "Yes" as danger (red). 
For example fields like "is_deleted", "is_deactivated", "is_banned" etc. It would be nice to have green "No" for such situations.

Usage:
```php
// in a controller
$action = $this->Crud->action();
$fields['is_deactivated'] = ['inverted' => true];
$action->config('scaffold.fields', $fields);
```