### PR TITLE
Added more actions on view/edit pages

### DIFF
--- a/src/Template/Element/action-header.ctp
+++ b/src/Template/Element/action-header.ctp
@@ -5,6 +5,13 @@ if (!$this->exists('actions')) {
             'actions' => $actions['table'],
             'singularVar' => false,
         ]);
+        // to make sure ${$viewVar} is a single entity, not a collection
+        if (${$viewVar} instanceof \Cake\Datasource\EntityInterface) {
+            echo $this->element('actions', [
+                'actions' => $actions['entity'],
+                'singularVar' => ${$viewVar},
+            ]);
+        }
     $this->end();
 }
 ?>

--- a/src/Template/Scaffold/view.ctp
+++ b/src/Template/Scaffold/view.ctp
@@ -7,7 +7,7 @@ $assocMap = isset($associations['manyToOne']) ?
 ?>
 <?= $this->fetch('before_view'); ?>
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
-    <h2><?= $this->get('title');?></h2>
+    <?= $this->element('action-header') ?>
     <table class="table">
         <?php
         $this->CrudView->setContext(${$viewVar});


### PR DESCRIPTION
The issue:
Only "Index" action is available on "View" page.
Nothing at all is available on "Edit" page.

This PR fixes the issue.
All available actions are shown on the edit/view pages.
