### PR TITLE
Feature proposal: Detect unsaved changes and show warning on page close

### DIFF
--- a/config/defaults.php
+++ b/config/defaults.php
@@ -15,7 +15,8 @@ return [
                 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.3/moment-with-locales.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/js/bootstrap-datetimepicker.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js'
+                'https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js',
+                'https://cdn.jsdelivr.net/jquery.dirtyforms/1.2.2/jquery.dirtyforms.min.js'
             ],
             'script' => [
                 'CrudView.local'

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -68,6 +68,7 @@ class ViewListener extends BaseListener
         $controller->set('formUrl', $this->_getFormUrl());
         $controller->set('disableExtraButtons', $this->_getDisableExtraButtons());
         $controller->set('extraButtonsBlacklist', $this->_getExtraButtonsBlacklist());
+        $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
         $controller->set($this->_getPageVariables());
     }
 
@@ -516,5 +517,16 @@ class ViewListener extends BaseListener
     {
         $action = $this->_action();
         return $action->config('scaffold.extra_buttons_blacklist') ?: [];
+    }
+
+    /**
+     * Get enable dirty check setting
+     *
+     * @return bool
+     */
+    protected function _getEnableDirtyCheck()
+    {
+        $action = $this->_action();
+        return $action->config('scaffold.enable_dirty_check') ?: false;
     }
 }

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -3,7 +3,7 @@
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
     <?= $this->element('action-header') ?>
 
-    <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl]); ?>
+    <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl, 'data-dirty-check' => $enableDirtyCheck]); ?>
     <?= $this->CrudView->redirectUrl(); ?>
     <div class="row">
         <div class="col-lg-<?= $this->exists('form.sidebar') ? '8' : '12' ?>">

--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -57,4 +57,7 @@ $(document).on('ready', function() {
             }
         });
     });
+
+    $.DirtyForms.dialog = false;
+    $('form[data-dirty-check=1]').dirtyForms();
 });


### PR DESCRIPTION
Show "Are you sure?" warning if a page is closed/reloaded while form contains unsaved changes.
The option `enable_dirty_check` is **disabled** by default.

To enable it:
```
// in a controller
$action = $this->Crud->action();
if ($this->request->action === 'edit') {
    $action->config('scaffold.enable_dirty_check', true);
}
```