### PR TITLE
Action groups

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -6,6 +6,7 @@ use Cake\Event\Event;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Crud\Listener\BaseListener;
+use Cake\Collection\Collection;
 
 class ViewListener extends BaseListener
 {
@@ -69,6 +70,7 @@ class ViewListener extends BaseListener
         $controller->set('disableExtraButtons', $this->_getDisableExtraButtons());
         $controller->set('extraButtonsBlacklist', $this->_getExtraButtonsBlacklist());
         $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
+        $controller->set('actionGroups', $this->_getActionGroups());
         $controller->set($this->_getPageVariables());
     }
 
@@ -551,5 +553,22 @@ class ViewListener extends BaseListener
     {
         $action = $this->_action();
         return $action->config('scaffold.enable_dirty_check') ?: false;
+    }
+
+    /**
+     * Get action groups
+     *
+     * @return array
+     */
+    protected function _getActionGroups()
+    {
+        $action = $this->_action();
+        $groups = $action->config('scaffold.action_groups') ?: [];
+
+        $groupedActions = (new Collection($groups))->unfold()->toList();
+
+        // add "primary" actions (primary should rendered as separate buttons)
+        $groups['primary'] = array_diff(array_keys($this->_getAllowedActions()), $groupedActions);
+        return $groups;
     }
 }

--- a/src/Template/Element/action-button.ctp
+++ b/src/Template/Element/action-button.ctp
@@ -1,0 +1,19 @@
+<?php
+if (is_array($config)) {
+    if ($config['method'] !== 'GET') {
+        echo $this->Form->postLink(
+            $config['title'],
+            $config['url'],
+            $config['options']
+        );
+    } else {
+        echo $this->Html->link(
+            $config['title'],
+            $config['url'],
+            $config['options']
+        );
+    }
+} else {
+    echo $config;
+}
+?>

--- a/src/Template/Element/action-button.ctp
+++ b/src/Template/Element/action-button.ctp
@@ -1,19 +1,12 @@
 <?php
-if (is_array($config)) {
-    if ($config['method'] !== 'GET') {
-        echo $this->Form->postLink(
-            $config['title'],
-            $config['url'],
-            $config['options']
-        );
-    } else {
-        echo $this->Html->link(
-            $config['title'],
-            $config['url'],
-            $config['options']
-        );
-    }
-} else {
+if (!is_array($config)) {
     echo $config;
+    return;
 }
-?>
+
+if ($config['method'] !== 'GET') {
+    echo $this->Form->postLink($config['title'], $config['url'], $config['options']);
+    return;
+}
+
+echo $this->Html->link($config['title'], $config['url'], $config['options']);

--- a/src/Template/Element/action-groups.ctp
+++ b/src/Template/Element/action-groups.ctp
@@ -1,0 +1,30 @@
+<?php
+// check if groups are not empty
+foreach ($groups as $key => $group) {
+    $exists = false;
+    foreach ($group as $action) {
+        if (array_key_exists($action, $links)) {
+            $exists = true;
+        }
+    }
+    if (!$exists) {
+        unset($groups[$key]);
+    }
+}
+?>
+
+<?php foreach ($groups as $key => $group) : ?>
+    <div class='btn-group'>
+        <?= $this->Html->link(
+            sprintf("%s %s", $key, $this->Html->tag('span', null, ['class' => 'caret'])),
+            '#',
+            ['class' => 'btn btn-default dropdown-toggle', 'escape' => false, 'data-toggle' => 'dropdown', 'aria-haspopup' => true, 'aria-expanded' => false]);
+        ?>
+        <ul class="dropdown-menu pull-right">
+            <?php foreach ($group as $subaction) : ?>
+                <li><?= $this->element('action-button', ['config' => $links[$subaction]]); ?></li>
+            <?php endforeach; ?>
+       </ul>
+   </div>
+<?php endforeach; ?>
+

--- a/src/Template/Element/action-groups.ctp
+++ b/src/Template/Element/action-groups.ctp
@@ -22,7 +22,9 @@ foreach ($groups as $key => $group) {
         ?>
         <ul class="dropdown-menu pull-right">
             <?php foreach ($group as $subaction) : ?>
-                <li><?= $this->element('action-button', ['config' => $links[$subaction]]); ?></li>
+                <?php if (array_key_exists($subaction, $links)): ?>
+                    <li><?= $this->element('action-button', ['config' => $links[$subaction]]); ?></li>
+                <?php endif; ?>
             <?php endforeach; ?>
        </ul>
    </div>

--- a/src/Template/Element/action-header.ctp
+++ b/src/Template/Element/action-header.ctp
@@ -16,4 +16,7 @@ if (!$this->exists('actions')) {
 }
 ?>
 <h2><?= $this->get('title'); ?></h2>
-<p class="actions"><?= $this->fetch('actions'); ?></p>
+<div class="actions-wrapper">
+    <?= $this->fetch('actions'); ?>
+    <div style="clear: both;"></div>
+</div>

--- a/webroot/css/local.css
+++ b/webroot/css/local.css
@@ -59,3 +59,11 @@ h2 .actions {
 .selectize-input.items.full {
     padding-right:33px;
 }
+
+div.actions-wrapper {
+    margin: 10px 0;
+}
+
+div.actions-holder {
+    float: left;
+}

--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -60,4 +60,14 @@ $(document).on('ready', function() {
 
     $.DirtyForms.dialog = false;
     $('form[data-dirty-check=1]').dirtyForms();
+
+    $('.dropdown-toggle').dropdown();
+
+    // recommended hack to get dropdowns correctly work inside responsive table
+    $('.table-responsive').on('show.bs.dropdown', function () {
+        $('.table-responsive').css( "overflow", "inherit" );
+    });
+    $('.table-responsive').on('hide.bs.dropdown', function () {
+        $('.table-responsive').css( "overflow", "auto" );
+    })
 });


### PR DESCRIPTION
Added possibility to group actions. Few actions can be grouped into one dropdown list.

Config:
```    
// in a controller
$action->config('scaffold.action_groups', [
    'Extras' => ['edit', 'publish', 'deactivate']
]);
```

Result:
![Image](https://photos-1.dropbox.com/t/2/AAD45ve-2Xm6BeozZxWv_zjkOERR_5pUsDYGAilqV0E5Qg/12/6314564/png/32x32/1/1437480000/0/2/Screenshot%202015-07-21%2012.13.59.png/CMS0gQMgASACIAMgBCAFIAYgBygBKAIoBw/9iPK86JfP0tF7qKQfzduPPDAMYNzcrt3qrsX3gETYVE?size=1600x1200&size_mode=2)

Important notes
- Actions out of groups will be rendered as separate buttons (like "View" on the image above)
- Scope (entity OR table) is still defined by an action, not a group. It means if no actions are available in the current scope a group will be just ignored and not rendered.
