### PR TITLE
Fixed action bug on add view

### DIFF
--- a/src/Template/Element/action-header.ctp
+++ b/src/Template/Element/action-header.ctp
@@ -6,7 +6,7 @@ if (!$this->exists('actions')) {
             'singularVar' => false,
         ]);
         // to make sure ${$viewVar} is a single entity, not a collection
-        if (${$viewVar} instanceof \Cake\Datasource\EntityInterface) {
+        if (${$viewVar} instanceof \Cake\Datasource\EntityInterface && !${$viewVar}->isNew()) {
             echo $this->element('actions', [
                 'actions' => $actions['entity'],
                 'singularVar' => ${$viewVar},


### PR DESCRIPTION
After discussion with @lorenzo we've found that in the CRUD `add` action is specified as `entity` action.
This is the reason of the bug on the Add view (entity actions can't be rendered).

This PR provides a fix.