### PR TITLE
Fix action titles

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -341,7 +341,7 @@ class ViewListener extends BaseListener
             $method = isset($config['method']) ? $config['method'] : 'GET';
 
             ${$scope}[$actionName] = [
-                'title' => Inflector::humanize($actionName),
+                'title' => Inflector::humanize(Inflector::underscore($actionName)),
                 'url' => [
                     'action' => $actionName
                 ],


### PR DESCRIPTION
This makes it so an action `tasksByUser` becomes "Tasks By User" in the UI, instead of "TasksByUser".

<img width="184" alt="screenshot 2015-07-23 17 14 32" src="https://cloud.githubusercontent.com/assets/24155/8863441/61555ad2-315e-11e5-8de6-42c69d799ddf.png">
