### PR TITLE
Bump moment.js version

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -7,7 +7,7 @@ files[]=plugin:CrudView:css/local.css
 [crudview_head.js]
 files[]=https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js
-files[]=https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.3/moment-with-locales.min.js
+files[]=https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/js/bootstrap-datetimepicker.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js
 files[]=https://cdn.jsdelivr.net/jquery.dirtyforms/1.2.2/jquery.dirtyforms.min.js

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -13,7 +13,7 @@ return [
             'headjs' => [
                 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.3/moment-with-locales.min.js',
+                'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/js/bootstrap-datetimepicker.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js',
                 'https://cdn.jsdelivr.net/jquery.dirtyforms/1.2.2/jquery.dirtyforms.min.js'


### PR DESCRIPTION
Using Livestamp.js, I ran into an issue with locales in moment.js:

<img width="137" alt="screenshot 2015-07-29 21 39 32" src="https://cloud.githubusercontent.com/assets/24155/8974703/75e7d994-363a-11e5-9bee-2a136f709c45.png">

Bumping the version means I can remove this temporary fix:

```php
// Force locale to English rather than the last locale loaded, Chinese.
// @todo Wait for https://github.com/moment/moment/issues/2367 to be closed.
// @todo Submit PR to bump moment.js version in CrudView
moment.locale('en'); // @todo Remove this line once above done.
```