### PR TITLE
Improved field "autocomplete" logic in SearchListener

### DIFF
--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -123,7 +123,9 @@ class SearchListener extends BaseListener
                 continue;
             }
 
-            $input['class'] = 'autocomplete';
+            if (empty($input['class'])) {
+                $input['class'] = 'autocomplete';
+            }
 
             if (empty($input['type'])) {
                 $input['type'] = 'text';
@@ -142,8 +144,6 @@ class SearchListener extends BaseListener
 
             $fields[$searchParam] = $input;
         }
-
-        // debug($fields);
         return $fields;
     }
 }


### PR DESCRIPTION
Not always a search field has to be "autocompletable" (for instance date/time filters). And in general it's nice to have possibility to customize "class" attribute.