### PR TITLE
Move 'action_link_forms' block to layout

### DIFF
--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -33,6 +33,7 @@
             <div class="col-xs-12 col-sm-10 col-lg-10">
                 <?= $this->Flash->render(); ?>
                 <?= $this->fetch('content'); ?>
+                <?= $this->fetch('action_link_forms'); ?>
             </div>
         </div>
     </div>

--- a/src/Template/Scaffold/index.ctp
+++ b/src/Template/Scaffold/index.ctp
@@ -59,7 +59,6 @@
     </div>
 
     <?= $this->element('index/bulk_actions/form_end', compact('bulkActions')); ?>
-    <?= $this->fetch('action_link_forms') ?>
     <?= $this->element('index/pagination'); ?>
 </div>
 


### PR DESCRIPTION
The 'Delete' action is a post link but the block for it was only present on the index template.

Moving the block to the the same element means the button works on all pages it appears on.

https://github.com/FriendsOfCake/crud-view/blob/master/src/Template/Element/actions.ctp#L19