### PR TITLE
DELETE method button not generated correctly

### DIFF
--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -45,7 +45,7 @@ foreach ($actions as $name => $config) {
         $links[$name] = $this->Form->postLink(
             $config['title'],
             $url,
-            $linkOptions
+            $linkOptions + ['class'=>'btn btn-default']
         );
         continue;
     }
@@ -67,6 +67,10 @@ foreach ($actions as $name => $config) {
             continue;
         }
         $config = $links[$action];
+        if( is_string($config)) {
+          echo $config;
+          continue;
+        }
         $config['options']['class'] = ['btn btn-default'];
 
         echo $this->element('action-button', ['config' => $config]);


### PR DESCRIPTION
Non GET type buttons are generated as links on line 45 but remain in the config array. 
This causes a fatal error on line 74 when ['options]['class'] is set on a string. If the link
was already generated then we can just echo that string and continue building the rest
of the links from the config.