### PR TITLE
Added support for default empty datetime value

### DIFF
--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -13,10 +13,14 @@ $(document).on('ready', function() {
     }
 
     $('[role=datetime-picker]').each(function() {
+        var date = new Date($(this).data('timestamp') * 1000);
+        if ($(this).data('timestamp') === '') {
+            date = '' ;
+        };
         $(this).datetimepicker({
             locale: $(this).data('locale'),
             format: $(this).data('format'),
-            date: new Date($(this).data('timestamp') * 1000)
+            date: date
         });
     });
 


### PR DESCRIPTION
An empty value should not be converted to "01/01/1970...".