### PR TITLE
Allow disabling contain of all relations

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -143,6 +143,10 @@ class ViewListener extends BaseListener
     {
         $models = $this->_action()->config('scaffold.relations');
 
+        if ($models === false) {
+            return [];
+        }
+
         if (empty($models)) {
             $associations = $this->_associations();
 


### PR DESCRIPTION
Allows you to `$action->config('scaffold.relations', false);` as opposed to blacklisting.