### PR TITLE
Fix datepicker issues

### DIFF
--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -1,6 +1,6 @@
 [crudview.css]
 files[]=https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css
-files[]=https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/css/bootstrap-datetimepicker.min.css
+files[]=https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/css/bootstrap-datetimepicker.min.css
 files[]=https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.min.css
 files[]=plugin:CrudView:css/local.css
 
@@ -8,7 +8,7 @@ files[]=plugin:CrudView:css/local.css
 files[]=https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.min.js
-files[]=https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/js/bootstrap-datetimepicker.min.js
+files[]=https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/js/bootstrap-datetimepicker.min.js
 files[]=https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js
 files[]=https://cdn.jsdelivr.net/jquery.dirtyforms/1.2.2/jquery.dirtyforms.min.js
 

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -5,7 +5,7 @@ return [
         'brand' => 'Crud View',
         'css' => [
             'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css',
-            'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/css/bootstrap-datetimepicker.min.css',
+            'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/css/bootstrap-datetimepicker.min.css',
             'https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.min.css',
             'CrudView.local'
         ],
@@ -14,7 +14,7 @@ return [
                 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/js/bootstrap.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment-with-locales.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.14.30/js/bootstrap-datetimepicker.min.js',
+                'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/js/bootstrap-datetimepicker.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js',
                 'https://cdn.jsdelivr.net/jquery.dirtyforms/1.2.2/jquery.dirtyforms.min.js'
             ],

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -1,5 +1,4 @@
 <?php
-
 return [
     'CrudView' => [
         'brand' => 'Crud View',
@@ -21,6 +20,7 @@ return [
             'script' => [
                 'CrudView.local'
             ]
-        ]
+        ],
+        'timezoneAwareDateTimeWidget' => false,
     ]
 ];

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -25,7 +25,6 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         $type = $data['type'];
         $required = $data['required'] ? 'required' : '';
         $format = null;
-        $timestamp = null;
         $locale = locale_get_primary_language(I18n::locale());
 
         if (isset($data['data-format'])) {
@@ -37,7 +36,6 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         }
 
         if ($val) {
-            $timestamp = $val->format('U');
             $val = $val->format($type === 'date' ? 'Y-m-d' : 'Y-m-d H:i:s');
         }
 
@@ -56,7 +54,6 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
                     role="datetime-picker"
                     data-locale="$locale"
                     data-format="$format"
-                    data-timestamp="$timestamp"
                     $required
                 />
                 <span class="input-group-addon">

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -27,6 +27,12 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         $format = null;
         $locale = I18n::locale();
 
+        // @todo this value needs to be configured
+        $timezoneAware = false;
+
+        $timestamp = null;
+        $timezoneOffset = null;
+
         if (isset($data['data-format'])) {
             $format = $this->_convertPHPToMomentFormat($data['data-format']);
         }
@@ -36,6 +42,9 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         }
 
         if ($val) {
+            $timestamp = $val->format('U');
+            $dateTimeZone = new \DateTimeZone(date_default_timezone_get());
+            $timezoneOffset = ($dateTimeZone->getOffset($val) / 60);
             $val = $val->format($type === 'date' ? 'Y-m-d' : 'Y-m-d H:i:s');
         }
 
@@ -54,6 +63,14 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
                     role="datetime-picker"
                     data-locale="$locale"
                     data-format="$format"
+html;
+        if ($timezoneAware && isset($timestamp, $timezoneOffset)) {
+            $widget .= <<<html
+                    data-timestamp="$timestamp"
+                    data-timezone-offset="$timezoneOffset"
+html;
+        }
+        $widget .= <<<html
                     $required
                 />
                 <span class="input-group-addon">

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -25,7 +25,7 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         $type = $data['type'];
         $required = $data['required'] ? 'required' : '';
         $format = null;
-        $locale = locale_get_primary_language(I18n::locale());
+        $locale = I18n::locale();
 
         if (isset($data['data-format'])) {
             $format = $this->_convertPHPToMomentFormat($data['data-format']);

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -1,6 +1,7 @@
 <?php
 namespace CrudView\View\Widget;
 
+use Cake\Core\Configure;
 use Cake\I18n\I18n;
 use Cake\I18n\Time;
 use Cake\View\Form\ContextInterface;
@@ -27,8 +28,7 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
         $format = null;
         $locale = I18n::locale();
 
-        // @todo this value needs to be configured
-        $timezoneAware = false;
+        $timezoneAware = Configure::read('CrudView.timezoneAwareDateTimeWidget');
 
         $timestamp = null;
         $timezoneOffset = null;

--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -13,10 +13,26 @@ $(document).on('ready', function() {
     }
 
     $('[role=datetime-picker]').each(function() {
-        $(this).datetimepicker({
+
+        var picker = $(this);
+        var date = null;
+
+        if (picker.data('timestamp') && picker.data('timezone-offset')) {
+            var timezoneOffset = picker.data('timezone-offset');
+            date = new Date(picker.data('timestamp') * 1000);
+
+            picker.parents('form').on('submit', function () {
+                var timezoneDiff = timezoneOffset + date.getTimezoneOffset();
+                var currentDate = picker.data('DateTimePicker').date();
+                var convertedDate = currentDate.add(timezoneDiff, 'minutes');
+                picker.data('DateTimePicker').date(convertedDate);
+            });
+        }
+
+        picker.datetimepicker({
             locale: $(this).data('locale'),
             format: $(this).data('format'),
-            date: $(this).val()
+            date: date ? date : picker.val()
         });
     });
 

--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -13,14 +13,10 @@ $(document).on('ready', function() {
     }
 
     $('[role=datetime-picker]').each(function() {
-        var date = new Date($(this).data('timestamp') * 1000);
-        if ($(this).data('timestamp') === '') {
-            date = '' ;
-        };
         $(this).datetimepicker({
             locale: $(this).data('locale'),
             format: $(this).data('format'),
-            date: date
+            date: $(this).val()
         });
     });
 


### PR DESCRIPTION
This PR solves 2 issues I came across while implementing Crud-View in one of my projects. And I also bumped the version of the datepicker.

**First issue:**
locale_get_primary_language() was used to strip the locale, that didn't work with locales like `en_GB`.

Discussed in the following issue: https://github.com/FriendsOfCake/crud-view/issues/88.

**Second issue:**
The date picker somehow used the clients timezone, so if the time on server said 08:00 UTC, the date picker would use 10:00 +02:00. Originally I thought it was about Moment.js used in the bootstrap-datetimepicker, but it turned out to be code in this Crud-view.

To be clear, this issue only occurs when the app's timezone, defined in `bootstrap.php` does not match the timezone used in the web browser.

@lorenzo What's your thought on this one? You've implemented the timestamp approach. Maybe there was some reasoning behind that approach I might have missed.

Discussed in the following issue: https://github.com/FriendsOfCake/crud-view/issues/87