### PR TITLE
Remove duplicate ID in page title

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -248,7 +248,7 @@ class ViewListener extends BaseListener
         }
 
         $displayFieldValue = $this->_displayFieldValue();
-        if ($displayFieldValue === null) {
+        if ($displayFieldValue === null || $this->_table()->displayField() == $this->_table()->primaryKey()) {
             return sprintf('%s %s #%s', $actionName, $controllerName, $primaryKeyValue);
         }
 


### PR DESCRIPTION
Currently when viewing or editing an entity, the display field is used for the page title. If the entity has no display field, it defaults to `id`. This causes page titles like:

> Edit Post *#*4: 4

This is annoying and useless. I fixed this by not adding the display field value in case the display field is the same as the primary key.