### PR TITLE
Fixed defining actions

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -380,7 +380,10 @@ class ViewListener extends BaseListener
     protected function _getAllowedActions()
     {
         $actions = $this->_action()->config('scaffold.actions');
-        $actions = ($actions === null) ? $this->_crud()->config('actions') : [];
+        if ($actions === null) {
+            $actions = $this->_crud()->config('actions');
+        }
+        
         $extraActions = $this->_action()->config('scaffold.extra_actions') ?: [];
 
         $allActions = array_merge(


### PR DESCRIPTION
When setting actions using `$action->config('scaffold.actions', $actions);`, it ended up without any actions at all. When fetching actions from config, it checked against `null` and used to set it to `$this->_crud()->config('actions')` as a default. If the actions from config weren't `null`, it was set to `[]`.

Changed the code so it only reassigned `$actions` if it is `null`.