### PR TITLE
Added ability to override controller action links’ text using `label`.

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -375,7 +375,7 @@ class ViewListener extends BaseListener
             $scope = isset($config['scope']) ? $config['scope'] : 'entity';
             $method = isset($config['method']) ? $config['method'] : 'GET';
 
-            $title = !empty($config['label']) ? $config['label'] : Inflector::humanize(Inflector::underscore($actionName));
+            $title = !empty($config['link_title']) ? $config['link_title'] : Inflector::humanize(Inflector::underscore($actionName));
 
             ${$scope}[$actionName] = [
                 'title' => $title,
@@ -385,7 +385,7 @@ class ViewListener extends BaseListener
                 'method' => $method,
                 'options' => array_diff_key(
                     $config,
-                    array_flip(['method', 'scope', 'className', 'label'])
+                    array_flip(['method', 'scope', 'className', 'link_title'])
                 )
             ];
             if (!empty($config['callback'])) {

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -375,15 +375,17 @@ class ViewListener extends BaseListener
             $scope = isset($config['scope']) ? $config['scope'] : 'entity';
             $method = isset($config['method']) ? $config['method'] : 'GET';
 
+            $title = !empty($config['label']) ? $config['label'] : Inflector::humanize(Inflector::underscore($actionName));
+
             ${$scope}[$actionName] = [
-                'title' => Inflector::humanize(Inflector::underscore($actionName)),
+                'title' => $title,
                 'url' => [
                     'action' => $actionName
                 ],
                 'method' => $method,
                 'options' => array_diff_key(
                     $config,
-                    array_flip(['method', 'scope', 'className'])
+                    array_flip(['method', 'scope', 'className', 'label'])
                 )
             ];
             if (!empty($config['callback'])) {


### PR DESCRIPTION
Added the ability to alter the link text of controller actions using `label` like this:-

```php
public function index()
{
    $action = $this->Crud->action();
    $action->config('scaffold.actions', ['edit', 'delete' => ['label' => __('Remove')]]);
    return $this->Crud->execute();
}
```

The thinking behind this is that you don't always want the link text to read as the action name. For example:-

 * You need to change the text without wanting to rename the action
 * You need to translate the text using `__()`

I've used the config option `label` rather than `title` as you may still want to have a `title` attribute on the link and for accessibility this shouldn't be a duplicate of the link text.