### PR TITLE
Use cloudflare's glyphicons

### DIFF
--- a/webroot/css/local.css
+++ b/webroot/css/local.css
@@ -1,4 +1,19 @@
 /******************************************************************************
+ * Use cloudflare's glyphicons
+ *****************************************************************************/
+@font-face {
+    font-family: 'Glyphicons Halflings';
+
+    src: url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.eot');
+    src: url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), 
+         url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.woff2') format('woff2'), 
+         url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.woff') format('woff'), 
+         url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.ttf') format('truetype'), 
+         url('https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+}
+
+
+/******************************************************************************
  * Generic form hacks
  *****************************************************************************/
 .bulk-action {


### PR DESCRIPTION
Right now, icons are broken when using AssetCompress. This fixes it by using the CloudFlare's CDN (which is also configured in the AssetCompress build file) for the glyphicons font-face. 