### PR TITLE
Read associations in beforeRender

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -63,7 +63,11 @@ class ViewListener extends BaseListener
         if (!empty($event->subject()->entity)) {
             $this->_entity = $event->subject()->entity;
         }
-
+        
+        if (empty($this->associations)) {
+            $this->associations = $this->_associations(array_keys($this->_getRelatedModels()));
+        }
+        
         $this->ensureConfig();
 
         $controller = $this->_controller();


### PR DESCRIPTION
`$this->associations` is only populated in `beforeFind` or `beforePaginate`, this means that association fields are not loaded for `Add` actions. This change populates it in the `beforeFind` callback if it has not already been populated.