### PR TITLE
Make usage of AssetCompress configurable.

### DIFF
--- a/config/defaults.php
+++ b/config/defaults.php
@@ -1,4 +1,6 @@
 <?php
+use \Cake\Core\Plugin;
+
 return [
     'CrudView' => [
         'brand' => 'Crud View',
@@ -22,5 +24,6 @@ return [
             ]
         ],
         'timezoneAwareDateTimeWidget' => false,
+        'useAssetCompress' => Plugin::loaded('AssetCompress')
     ]
 ];

--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -52,7 +52,7 @@ class CrudView extends View
      */
     protected function _loadAssets()
     {
-        if (Plugin::loaded('AssetCompress')) {
+        if (Configure::read('CrudView.useAssetCompress')) {
             $this->AssetCompress->css('CrudView.crudview', ['block' => true]);
             $this->AssetCompress->script('CrudView.crudview_head', ['block' => 'headjs']);
             $this->AssetCompress->script('CrudView.crudview', ['block' => true]);
@@ -95,7 +95,7 @@ class CrudView extends View
         $this->loadHelper('CrudView.CrudView');
         $this->loadHelper('BootstrapUI.Flash');
 
-        if (Plugin::loaded('AssetCompress')) {
+        if (Configure::read('CrudView.useAssetCompress')) {
             $this->loadHelper('AssetCompress.AssetCompress');
         }
     }


### PR DESCRIPTION
Don't like the implicit usage of AssetCompress helper. I use it for frontend but don't want to be bothered configuring crud view assets in asset_compress.ini for admin area.