### PR TITLE
Set CrudView in beforeRender()

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -59,9 +59,17 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
          */
         public function beforeRender(\Cake\Event\Event $event)
         {
+            // For CakePHP 3.1+
             if ($this->viewBuilder()->className() === null) {
                 $this->viewBuilder()->className('CrudView\View\CrudView');
             }
+            
+            // For CakePHP 3.0
+            /*
+            if ($this->viewClass === null) {
+                $this->viewClass == '\CrudView\View\CrudView';
+            }
+            */
         }
     }
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -32,7 +32,6 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
             $this->loadComponent('RequestHandler');
             $this->loadComponent('Flash');
 
-            $this->viewClass = 'CrudView\View\CrudView';
             $this->loadComponent('Crud.Crud', [
                 'actions' => [
                     'Crud.Index',
@@ -50,6 +49,19 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
                     'CrudView.Search',
                 ]
             ]);
+        }
+        
+        /**
+         * Before render callback.
+         *
+         * @param \Cake\Event\Event $event The beforeRender event.
+         * @return void
+         */
+        public function beforeRender(\Cake\Event\Event $event)
+        {
+            if ($this->viewBuilder()->className() === null) {
+                $this->viewBuilder()->className('CrudView\View\CrudView');
+            }
         }
     }
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -67,7 +67,7 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
             // For CakePHP 3.0
             /*
             if ($this->viewClass === null) {
-                $this->viewClass == '\CrudView\View\CrudView';
+                $this->viewClass = 'CrudView\View\CrudView';
             }
             */
         }


### PR DESCRIPTION
Setting CrudView in intialize() prevents RequestHandler from switching view class based on request type.