### PR TITLE
Remove the legend on search

### DIFF
--- a/src/Template/Element/search.ctp
+++ b/src/Template/Element/search.ctp
@@ -14,7 +14,6 @@ if (empty($searchInputs)) {
     ?>
 
     <fieldset>
-        <legend>Filter</legend>
         <?= $this->Form->inputs($searchInputs, ['fieldset' => false]); ?>
         <?= $this->Form->button('Filter results', ['type' => 'submit', 'class' => 'btn btn-primary']); ?>
     </fieldset>


### PR DESCRIPTION
Button makes it clear what this form is performing, and a user can easily create a legend using the searchOptions, or replace this element with their own