### PR TITLE
Remove autocomplete class as default attribute on search

### DIFF
--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -124,10 +124,6 @@ class ViewSearchListener extends BaseListener
                 continue;
             }
 
-            if (empty($input['class'])) {
-                $input['class'] = 'autocomplete';
-            }
-
             if (empty($input['type'])) {
                 $input['type'] = 'text';
             }


### PR DESCRIPTION
Searches are either on IDs or on text fields. As hooking up autocompletion isn't done automatically, we should also not assume every field is an autocomplete/dropdown field.