### PR TITLE
Site title

### DIFF
--- a/config/defaults.php
+++ b/config/defaults.php
@@ -4,6 +4,7 @@ use \Cake\Core\Plugin;
 return [
     'CrudView' => [
         'brand' => 'Crud View',
+        'siteTitle' => 'Crud View',
         'css' => [
             'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css',
             'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/css/bootstrap-datetimepicker.min.css',

--- a/docs/_themes/cakephp/layout.html
+++ b/docs/_themes/cakephp/layout.html
@@ -98,11 +98,9 @@ document.addEventListener('DOMContentLoaded', function (e) {
 <div id="container">
 {% endblock -%}
 
-
 {%- block relbar1 %}
 {%- include 'relbar1.html' %}
 {% endblock -%}
-
 
 {%- block content %}
 <div class="container page-container">

--- a/docs/_themes/cakephp/static/css/style.css
+++ b/docs/_themes/cakephp/static/css/style.css
@@ -1572,7 +1572,7 @@ blockquote {
 
 
 header {
-    background: #D33C44;
+    background: #F2626D;
     position: fixed;
     top: 0;
     transition: top 0.2s ease-in-out;

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -2,10 +2,17 @@ Contents
 ########
 
 .. toctree::
-   :maxdepth: 3
+   :hidden:
 
    index
-   installation
-   quick-start
-   basic-usage
-   customizing-templates
+
+.. toctree::
+   :maxdepth: 3
+
+    Installation <installation>
+
+    Quick Start <quick-start>
+    Basic Usage <basic-usage>
+    Customizing Templates <customizing-templates>
+
+    Site Title Options <site-title-options>

--- a/docs/site-title-options.rst
+++ b/docs/site-title-options.rst
@@ -1,0 +1,41 @@
+Site Title Options
+==================
+
+Every page has what's called the site title on the left side of the menu bar. If you want, you can customize it.
+
+Site Title
+----------
+
+You can use the ``scaffold.site_title`` config variable to modify the title. If not set, it will fallback to the following deprecated alternatives:
+
+- ``Configure::read('CrudView.siteTitle')``
+- ``$action->config('scaffold.brand')``: Deprecated
+- ``Configure::read('CrudView.brand')``: Deprecated
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.site_title', 'My Admin Site');
+
+Site Title Link
+---------------
+
+You can use the ``scaffold.site_title_link`` config variable to modify the title link. If not set, the title will not be made into a link. Both urls and cakephp route arrays are supported.
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.site_title_link', '/');
+
+Site Title Image
+----------------
+You can use the ``scaffold.site_title_image`` config variable to modify the title link. If set, it replaces ``scaffold.site_title``.
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    // Use an image included in your codebase
+    $action->config('scaffold.site_title_image', 'site_image.png');
+
+    // Use an exact url
+    $action->config('scaffold.site_title_image', 'http://www.google.com/images/logos/google_logo_41.png');

--- a/src/Listener/Traits/SiteTitleTrait.php
+++ b/src/Listener/Traits/SiteTitleTrait.php
@@ -1,0 +1,91 @@
+<?php
+namespace CrudView\Listener\Traits;
+
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Utility\Inflector;
+
+trait SiteTitleTrait
+{
+    /**
+     * beforeRender event
+     *
+     * @param \Cake\Event\Event $event Event.
+     * @return void
+     */
+    public function beforeRenderSiteTitle(Event $event)
+    {
+        $controller = $this->_controller();
+
+        $siteTitle = $this->_getSiteTitle();
+        $controller->set('siteTitle', $siteTitle);
+        $controller->set('siteTitleLink', $this->_getSiteTitleLink());
+        $controller->set('siteTitleImage', $this->_getSiteTitleImage());
+
+        // deprecated
+        $controller->set('brand', $siteTitle);
+    }
+
+
+    /**
+     * Get the brand name to use in the default template.
+     *
+     * @return string
+     */
+    protected function _getSiteTitle()
+    {
+        $action = $this->_action();
+
+        $title = $action->config('scaffold.site_title');
+        if (!empty($title)) {
+            return $title;
+        }
+
+        $title = Configure::read('CrudView.siteTitle');
+        if (!empty($title)) {
+            return $title;
+        }
+
+        // deprecated
+        $title = $action->config('scaffold.brand');
+        if (!empty($title)) {
+            return $title;
+        }
+
+        return Configure::read('CrudView.brand');
+    }
+
+    /**
+     * Returns the sites title link to show on scaffolded view
+     *
+     * @return string
+     */
+    protected function _getSiteTitleLink()
+    {
+        $action = $this->_action();
+
+        $link = $action->config('scaffold.site_title_link');
+        if (empty($link)) {
+            $link = '';
+        }
+
+        return $link;
+    }
+
+    /**
+     * Returns the sites title image to show on scaffolded view
+     *
+     * @return string
+     */
+    protected function _getSiteTitleImage()
+    {
+        $action = $this->_action();
+
+        $image = $action->config('scaffold.site_title_image');
+        if (empty($image)) {
+            $image = '';
+        }
+
+        return $image;
+    }
+}

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -6,12 +6,14 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use CrudView\Listener\Traits\SiteTitleTrait;
 use CrudView\Traits\CrudViewConfigTrait;
 use Crud\Listener\BaseListener;
 
 class ViewListener extends BaseListener
 {
     use CrudViewConfigTrait;
+    use SiteTitleTrait;
 
     /**
      * Default associations config
@@ -70,9 +72,9 @@ class ViewListener extends BaseListener
 
         $this->ensureConfig();
 
+        $this->beforeRenderSiteTitle($event);
         $controller = $this->_controller();
         $controller->set('actionConfig', $this->_action()->config());
-        $controller->set('brand', $this->_getBrand());
         $controller->set('title', $this->_getPageTitle());
         $associations = $this->associations;
         $controller->set(compact('associations'));
@@ -117,21 +119,6 @@ class ViewListener extends BaseListener
     {
         unset($event->subject()->params['class']);
         $event->subject()->element = ltrim($event->subject()->type);
-    }
-
-    /**
-     * Get the brand name to use in the default template.
-     *
-     * @return string
-     */
-    protected function _getBrand()
-    {
-        $brand = $this->_action()->config('scaffold.brand');
-        if (!empty($brand)) {
-            return $brand;
-        }
-
-        return Configure::read('CrudView.brand');
     }
 
     /**

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -2,7 +2,7 @@
 <html lang="<?= \Locale::getPrimaryLanguage(\Cake\I18n\I18n::locale()) ?>">
 <head>
     <?= $this->Html->charset(); ?>
-    <title><?= $this->get('title');?></title>
+    <title><?= $this->get('siteTitle');?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <?= $this->Html->meta('icon'); ?>
@@ -20,7 +20,17 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="/"><?= $brand ?></a>
+                <?php
+                    $siteTitleContent = $siteTitle;
+                    if (!empty($siteTitleImage)) {
+                        $siteTitleContent = $this->Html->image($siteTitleImage);
+                    }
+                    if (empty($siteTitleLink)) {
+                        echo $this->Html->tag('span', $siteTitleContent, ['class' => 'navbar-brand', 'escape' => false]);
+                    } else {
+                        echo $this->Html->link($siteTitleContent, $siteTitleLink, ['class' => 'navbar-brand', 'escape' => false]);
+                    }
+                ?>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
This changes the `scaffold.brand` functionality to `scaffold.site_title`. You will now be allowed to customize the url as well as replace the content with an image.
