### PR TITLE
refactor: deprecate the scaffold.disable_sidebar config option

### DIFF
--- a/docs/customizing-templates.rst
+++ b/docs/customizing-templates.rst
@@ -215,30 +215,6 @@ title for any of the fields by using the ``scaffold.fields`` configuration
         }
     }
 
-Disabling the Sidebar
----------------------
-
-There are cases where you may wish to disable the sidebar. For instance, you
-may be implementing crud-view for just a single table, or have all navigation
-in your header. You can disable it using the ``scaffold.disable_sidebar``
-configuration key:
-
-
-.. code-block:: php
-
-    <?php
-    namespace App\Controller;
-
-    class ArticlesController extends AppController
-    {
-        public function beforeFilter()
-        {
-            parent::beforeFilter();
-            $action = $this->Crud->action();
-            $action->config('scaffold.disable_sidebar', false);
-        }
-    }
-
 Overriding Template Parts
 -------------------------
 

--- a/src/Listener/Traits/SidebarNavigationTrait.php
+++ b/src/Listener/Traits/SidebarNavigationTrait.php
@@ -14,7 +14,9 @@ trait SidebarNavigationTrait
     public function beforeRenderSidebarNavigation(Event $event)
     {
         $controller = $this->_controller();
-        $controller->set('sidebarNavigation', $this->_getSidebarNavigation());
+        $sidebarNavigation = $this->_getSidebarNavigation();
+        $controller->set('disableSidebar', ($sidebarNavigation === false) ? true : false);
+        $controller->set('sidebarNavigation', $sidebarNavigation);
     }
 
     /**
@@ -25,6 +27,11 @@ trait SidebarNavigationTrait
     protected function _getSidebarNavigation()
     {
         $action = $this->_action();
+
+        // deprecated check
+        if ($action->config('scaffold.disable_sidebar')) {
+            return false;
+        }
 
         return $action->config('scaffold.sidebar_navigation');
     }

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -94,7 +94,6 @@ class ViewListener extends BaseListener
         $controller->set('viewblocks', $this->_getViewBlocks());
         $controller->set('formUrl', $this->_getFormUrl());
         $controller->set('disableExtraButtons', $this->_getDisableExtraButtons());
-        $controller->set('disableSidebar', $this->_getDisableSidebar());
         $controller->set('extraButtonsBlacklist', $this->_getExtraButtonsBlacklist());
         $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
         $controller->set('actionGroups', $this->_getActionGroups());
@@ -588,18 +587,6 @@ class ViewListener extends BaseListener
         $action = $this->_action();
 
         return $action->config('scaffold.disable_extra_buttons') ?: false;
-    }
-
-    /**
-     * Disable sidebar.
-     *
-     * @return bool
-     */
-    protected function _getDisableSidebar()
-    {
-        $action = $this->_action();
-
-        return $action->config('scaffold.disable_sidebar') ?: false;
     }
 
     /**


### PR DESCRIPTION
We can now set `scaffold.sidebar_navigation` to false to disable the sidebar, and thus can remove that setting.