### PR TITLE
refactor: Simplify forms

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -45,3 +45,11 @@ Contents
     Custom Index <index-pages/components/custom>
     Index as a Blog <index-pages/components/blog>
     Index as a Table <index-pages/components/table>
+
+.. _form-pages-docs:
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Form Pages
+
+   Customizing the Form <form-pages/customizing-the-form-page>

--- a/docs/form-pages/customizing-the-form-page.rst
+++ b/docs/form-pages/customizing-the-form-page.rst
@@ -138,8 +138,8 @@ The following custom view blocks are available for use within forms:
 
 - ``form.sidebar``: Rendered on the side of a form. Will also change the form
   width
-- ``form.before``: Rendered before a form.
-- ``form.after``: Rendered after a form.
+- ``form.before_create``: Rendered before ``FormHelper::create()`` is called
+- ``form.after_end``: Rendered after ``FormHelper::end()`` is called
 
 Form Action Elements
 ---------------------

--- a/docs/form-pages/customizing-the-form-page.rst
+++ b/docs/form-pages/customizing-the-form-page.rst
@@ -1,0 +1,164 @@
+Customizing the Form Page
+=========================
+
+Customizing Form Fields
+-----------------------
+
+Form fields may be specified via the ``scaffold.fields`` configuration key.
+By default, this will contain a list of all columns associated with the primary
+entity being edited. The value of this will be sent to ``FormHelper::inputs()``.
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.fields', ['title', 'description']);
+
+You may also use the ``scaffold.fields_blacklist`` configuration key to remove
+fields from the output if you are using the default automatic field population
+functionality:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.fields_blacklist', ['created', 'modified']);
+
+Finally, if you wish to use the default automatic field population functionality
+but want to specify settings for a few of the fields, you can use the
+``scaffold.field_settings`` configuration key:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.field_settings', [
+        'title' => [
+          'placeholder' => 'the title of the blog post'
+        ]
+    ]);
+
+Form Submission
+---------------
+
+Form Submission Redirect
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the Crud plugin will redirect all form submissions to the
+controller's ``index`` action. This can be changed by setting the
+``_redirect_url`` view variable:
+
+.. code-block:: php
+
+    $this->set('_redirect_url', ['action' => 'home']);
+
+Form Submission Check
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, closing the a form page in your browser will result in lost data.
+However, you may force a user prompt by enabling dirty form checks using the
+``scaffold.form_enable_dirty_check`` configuration key:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_enable_dirty_check', true);
+
+Submit Buttons
+--------------
+
+Changing the Submit Button Text
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can change the submit button text from it's default using the
+``scaffold.form_submit_button_text`` configuration key.
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_button_text', _('Submit'));
+
+Modifying the Default Extra Buttons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, we should the following extra buttons for forms:
+
+- Save & continue editing: Results in a form submission
+- Save & create new: Results in a form submission
+- Back: A link to the index page
+
+To use the defaults, you may either omit the configuration key **or** set it
+to true:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_buttons', true);
+
+You can also customize this by using the ``scaffold.form_submit_extra_buttons``
+configuration key as follows:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_buttons', [
+        [
+            'title' => __d('crud', 'Save & continue editing'),
+            'options' => ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true],
+            'type' => 'button',
+        ],
+        [
+            'title' => __d('crud', 'Save & create new'),
+            'options' => ['class' => 'btn btn-success', 'name' => '_add', 'value' => true],
+            'type' => 'button',
+        ],
+        [
+            'title' => __d('crud', 'Back'),
+            'url' => ['action' => 'index'],
+            'options' => ['class' => 'btn btn-default', 'role' => 'button', 'value' => true],
+            'type' => 'link',
+        ],
+    ]);
+
+Specified values will override the defaults, and will be output in the order
+specified.
+
+Disabling the Default Extra Buttons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rather than modifying the default extra buttons, you can also disable them
+completely:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_buttons', false);
+
+Custom Blocks
+-------------
+
+The following custom view blocks are available for use within forms:
+
+- ``form.sidebar``: Rendered on the side of a form. Will also change the form
+  width
+- ``form.before``: Rendered before a form.
+- ``form.after``: Rendered after a form.
+
+Form Action Elements
+---------------------
+
+All the ``CrudView`` templates are built from several elements that can be
+overridden by creating them in your own ``src/Template/Element`` folder. The
+following sections will list all the elements that can be overridden for each
+type of action.
+
+In general, if you want to override a template, it is a good idea to copy the
+original implementation from
+``vendor/friendsofcake/crud-view/src/Template/Element``
+
+action-header
+  Create ``src/Template/Element/action-header.ctp`` to have full control over
+  what is displayed at the top of the page. This is shared across all page
+  types.
+
+form/buttons
+  Create ``src/Template/Element/form/buttons.ctp`` to change what is displayed
+  for form submission. You can expect the ``$formSubmitButtonText`` and
+  ``$formSubmitExtraButtons`` variables to be available

--- a/docs/form-pages/customizing-the-form-page.rst
+++ b/docs/form-pages/customizing-the-form-page.rst
@@ -139,6 +139,8 @@ The following custom view blocks are available for use within forms:
 - ``form.sidebar``: Rendered on the side of a form. Will also change the form
   width
 - ``form.before_create``: Rendered before ``FormHelper::create()`` is called
+- ``form.after_create``: Rendered after ``FormHelper::create()`` is called
+- ``form.before_end``: Rendered before ``FormHelper::end()`` is called
 - ``form.after_end``: Rendered after ``FormHelper::end()`` is called
 
 Form Action Elements

--- a/src/Listener/Traits/DeprecatedConfigurationKeyTrait.php
+++ b/src/Listener/Traits/DeprecatedConfigurationKeyTrait.php
@@ -1,0 +1,20 @@
+<?php
+namespace CrudView\Listener\Traits;
+
+trait DeprecatedConfigurationKeyTrait
+{
+
+    /**
+     * Emit a deprecation notice for deprecated configuration key use
+     *
+     * @param $deprecatedKey string Name of key that is deprecated
+     * @param $newKey string Name of key that should be used instead of the deprecated key
+     * @return void
+     **/
+    protected function deprecatedScaffoldKeyNotice($deprecatedKey, $newKey)
+    {
+        $template = 'The configuration key %s has been deprecated. Use %s instead.';
+        $message = sprintf($template, $deprecatedKey, $newKey);
+        trigger_error($message, E_USER_DEPRECATED);
+    }
+}

--- a/src/Listener/Traits/DeprecatedConfigurationKeyTrait.php
+++ b/src/Listener/Traits/DeprecatedConfigurationKeyTrait.php
@@ -7,8 +7,8 @@ trait DeprecatedConfigurationKeyTrait
     /**
      * Emit a deprecation notice for deprecated configuration key use
      *
-     * @param $deprecatedKey string Name of key that is deprecated
-     * @param $newKey string Name of key that should be used instead of the deprecated key
+     * @param string $deprecatedKey Name of key that is deprecated
+     * @param string $newKey Name of key that should be used instead of the deprecated key
      * @return void
      **/
     protected function deprecatedScaffoldKeyNotice($deprecatedKey, $newKey)

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -44,7 +44,6 @@ trait FormTypeTrait
         return $action->config('scaffold.form_submit_button_text') ?: __d('crud', 'Save');
     }
 
-
     /**
      * Get extra form submit buttons.
      *

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -41,7 +41,7 @@ trait FormTypeTrait
         $formEnableDirtyCheck = $action->config('scaffold.form_enable_dirty_check');
         if ($formEnableDirtyCheck === null) {
             $formEnableDirtyCheck = $action->config('scaffold.enable_dirty_check');
-            if ($formSubmitButtonText !== null) {
+            if ($formEnableDirtyCheck !== null) {
                 $this->deprecatedScaffoldKeyNotice(
                     'scaffold.enable_dirty_check',
                     'scaffold.form_enable_dirty_check'

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -90,6 +90,7 @@ trait FormTypeTrait
                 'scaffold.disable_extra_buttons',
                 'scaffold.form_submit_extra_buttons'
             );
+
             return [];
         }
 
@@ -130,7 +131,6 @@ trait FormTypeTrait
             }
             $defaults = $newDefaults;
         }
-
 
         $buttons = $action->config('scaffold.form_submit_extra_buttons');
         if ($buttons === null || $buttons === true) {

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -85,7 +85,7 @@ trait FormTypeTrait
         $action = $this->_action();
 
         $disableExtraButtons = $this->_getFormDisableExtraButtons();
-        if ($disableExtraButtons === false) {
+        if ($disableExtraButtons === true) {
             $this->deprecatedScaffoldKeyNotice(
                 'scaffold.disable_extra_buttons',
                 'scaffold.form_submit_extra_buttons'

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -137,6 +137,10 @@ trait FormTypeTrait
             $buttons = $defaults;
         }
 
+        if ($buttons === false) {
+            $buttons = [];
+        }
+
         return $buttons;
     }
 

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -1,0 +1,95 @@
+<?php
+namespace CrudView\Listener\Traits;
+
+use Cake\Event\Event;
+
+trait FormTypeTrait
+{
+    /**
+     * beforeRender event
+     *
+     * @param \Cake\Event\Event $event Event.
+     * @return void
+     */
+    public function beforeRenderFormType(Event $event)
+    {
+        $controller = $this->_controller();
+        $controller->set('formEnableDirtyCheck', $this->_getFormEnableDirtyCheck());
+        $controller->set('formSubmitButtonText', $this->_getFormSubmitButtonText());
+        $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
+        $controller->set('formUrl', $this->_getFormUrl());
+    }
+
+    /**
+     * Get form enable dirty check setting
+     *
+     * @return bool
+     */
+    protected function _getFormEnableDirtyCheck()
+    {
+        $action = $this->_action();
+
+        return $action->config('scaffold.form_enable_dirty_check') ?: false;
+    }
+
+    /**
+     * Get form submit button text.
+     *
+     * @return bool
+     */
+    protected function _getFormSubmitButtonText()
+    {
+        $action = $this->_action();
+
+        return $action->config('scaffold.form_submit_button_text') ?: __d('crud', 'Save');
+    }
+
+
+    /**
+     * Get extra form submit buttons.
+     *
+     * @return bool
+     */
+    protected function _getFormSubmitExtraButtons()
+    {
+        $action = $this->_action();
+
+        $defaults = [
+            [
+                'title' => __d('crud', 'Save & continue editing'),
+                'options' => ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true],
+                'type' => 'button',
+            ],
+            [
+                'title' => __d('crud', 'Save & create new'),
+                'options' => ['class' => 'btn btn-success', 'name' => '_add', 'value' => true],
+                'type' => 'button',
+            ],
+            [
+                'title' => __d('crud', 'Back'),
+                'url' => ['action' => 'index'],
+                'options' => ['class' => 'btn btn-default', 'role' => 'button', 'value' => true],
+                'type' => 'link',
+            ],
+        ];
+
+        $buttons = $action->config('scaffold.form_submit_extra_buttons');
+        if ($buttons === null || $buttons === true) {
+            $buttons = $defaults;
+        }
+
+        return $buttons;
+    }
+
+    /**
+     * Get form url.
+     *
+     * @return mixed
+     */
+    protected function _getFormUrl()
+    {
+        $action = $this->_action();
+
+        return $action->config('scaffold.form_action') ?: null;
+    }
+}

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use CrudView\Listener\Traits\FormTypeTrait;
 use CrudView\Listener\Traits\IndexTypeTrait;
 use CrudView\Listener\Traits\SidebarNavigationTrait;
 use CrudView\Listener\Traits\SiteTitleTrait;
@@ -16,6 +17,7 @@ use Crud\Listener\BaseListener;
 class ViewListener extends BaseListener
 {
     use CrudViewConfigTrait;
+    use FormTypeTrait;
     use IndexTypeTrait;
     use SidebarNavigationTrait;
     use SiteTitleTrait;
@@ -78,6 +80,7 @@ class ViewListener extends BaseListener
 
         $this->ensureConfig();
 
+        $this->beforeRenderFormType($event);
         $this->beforeRenderIndexType($event);
         $this->beforeRenderSiteTitle($event);
         $this->beforeRenderUtilityNavigation($event);
@@ -93,10 +96,6 @@ class ViewListener extends BaseListener
         $controller->set('actions', $this->_getControllerActions());
         $controller->set('bulkActions', $this->_getBulkActions());
         $controller->set('viewblocks', $this->_getViewBlocks());
-        $controller->set('formUrl', $this->_getFormUrl());
-        $controller->set('formSubmitButtonText', $this->_getFormSubmitButtonText());
-        $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
-        $controller->set('formEnableDirtyCheck', $this->_getFormEnableDirtyCheck());
         $controller->set('actionGroups', $this->_getActionGroups());
         $controller->set($this->_getPageVariables());
     }
@@ -618,78 +617,6 @@ class ViewListener extends BaseListener
         $action = $this->_action();
 
         return $action->config('scaffold.bulk_actions') ?: [];
-    }
-
-    /**
-     * Get form url.
-     *
-     * @return mixed
-     */
-    protected function _getFormUrl()
-    {
-        $action = $this->_action();
-
-        return $action->config('scaffold.form_action') ?: null;
-    }
-
-    /**
-     * Get submit button text.
-     *
-     * @return bool
-     */
-    protected function _getFormSubmitButtonText()
-    {
-        $action = $this->_action();
-
-        return $action->config('scaffold.form_submit_button_text') ?: __d('crud', 'Save');
-    }
-
-    /**
-     * Disable extra buttons.
-     *
-     * @return bool
-     */
-    protected function _getFormSubmitExtraButtons()
-    {
-        $action = $this->_action();
-
-        $defaults = [
-            [
-                'title' => __d('crud', 'Save & continue editing'),
-                'options' => ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true],
-                'type' => 'button',
-            ],
-            [
-                'title' => __d('crud', 'Save & create new'),
-                'options' => ['class' => 'btn btn-success', 'name' => '_add', 'value' => true],
-                'type' => 'button',
-            ],
-            [
-                'title' => __d('crud', 'Back'),
-                'url' => ['action' => 'index'],
-                'options' => ['class' => 'btn btn-default', 'role' => 'button', 'value' => true],
-                'type' => 'link',
-            ],
-        ];
-
-        $buttons = $action->config('scaffold.form_submit_extra_buttons');
-        if ($buttons === null || $buttons === true) {
-            $buttons = $defaults;
-        }
-
-        return $buttons;
-    }
-
-    /**
-     * Get form enable dirty check setting
-     *
-     * @return bool
-     */
-    protected function _getFormEnableDirtyCheck()
-    {
-        $action = $this->_action();
-
-        return $action->config('scaffold.form_enable_dirty_check') ?: false;
     }
 
     /**

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -95,8 +95,7 @@ class ViewListener extends BaseListener
         $controller->set('viewblocks', $this->_getViewBlocks());
         $controller->set('formUrl', $this->_getFormUrl());
         $controller->set('submitButtonText', $this->_getSubmitButtonText());
-        $controller->set('disableExtraButtons', $this->_getDisableExtraButtons());
-        $controller->set('extraButtonsBlacklist', $this->_getExtraButtonsBlacklist());
+        $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
         $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
         $controller->set('actionGroups', $this->_getActionGroups());
         $controller->set($this->_getPageVariables());
@@ -650,23 +649,35 @@ class ViewListener extends BaseListener
      *
      * @return bool
      */
-    protected function _getDisableExtraButtons()
+    protected function _getFormSubmitExtraButtons()
     {
         $action = $this->_action();
 
-        return $action->config('scaffold.disable_extra_buttons') ?: false;
-    }
+        $defaults = [
+            [
+                'title' => __d('crud', 'Save & continue editing'),
+                'options' => ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true],
+                'type' => 'button',
+            ],
+            [
+                'title' => __d('crud', 'Save & create new'),
+                'options' => ['class' => 'btn btn-success', 'name' => '_add', 'value' => true],
+                'type' => 'button',
+            ],
+            [
+                'title' => __d('crud', 'Back'),
+                'url' => ['action' => 'index'],
+                'options' => ['class' => 'btn btn-default', 'role' => 'button', 'value' => true],
+                'type' => 'link',
+            ],
+        ];
 
-    /**
-     * Get extra buttons blacklist
-     *
-     * @return array
-     */
-    protected function _getExtraButtonsBlacklist()
-    {
-        $action = $this->_action();
+        $buttons = $action->config('scaffold.form_submit_extra_buttons');
+        if ($buttons === null || $buttons === true) {
+            $buttons = $defaults;
+        }
 
-        return $action->config('scaffold.extra_buttons_blacklist') ?: [];
+        return $buttons;
     }
 
     /**

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -94,7 +94,7 @@ class ViewListener extends BaseListener
         $controller->set('bulkActions', $this->_getBulkActions());
         $controller->set('viewblocks', $this->_getViewBlocks());
         $controller->set('formUrl', $this->_getFormUrl());
-        $controller->set('submitButtonText', $this->_getSubmitButtonText());
+        $controller->set('formSubmitButtonText', $this->_getFormSubmitButtonText());
         $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
         $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
         $controller->set('actionGroups', $this->_getActionGroups());
@@ -637,11 +637,11 @@ class ViewListener extends BaseListener
      *
      * @return bool
      */
-    protected function _getSubmitButtonText()
+    protected function _getFormSubmitButtonText()
     {
         $action = $this->_action();
 
-        return $action->config('scaffold.submit_button_text') ?: __d('crud', 'Save');
+        return $action->config('scaffold.form_submit_button_text') ?: __d('crud', 'Save');
     }
 
     /**

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -96,7 +96,7 @@ class ViewListener extends BaseListener
         $controller->set('formUrl', $this->_getFormUrl());
         $controller->set('formSubmitButtonText', $this->_getFormSubmitButtonText());
         $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
-        $controller->set('enableDirtyCheck', $this->_getEnableDirtyCheck());
+        $controller->set('formEnableDirtyCheck', $this->_getFormEnableDirtyCheck());
         $controller->set('actionGroups', $this->_getActionGroups());
         $controller->set($this->_getPageVariables());
     }
@@ -681,15 +681,15 @@ class ViewListener extends BaseListener
     }
 
     /**
-     * Get enable dirty check setting
+     * Get form enable dirty check setting
      *
      * @return bool
      */
-    protected function _getEnableDirtyCheck()
+    protected function _getFormEnableDirtyCheck()
     {
         $action = $this->_action();
 
-        return $action->config('scaffold.enable_dirty_check') ?: false;
+        return $action->config('scaffold.form_enable_dirty_check') ?: false;
     }
 
     /**

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
+use CrudView\Listener\Traits\DeprecatedConfigurationKeyTrait;
 use CrudView\Listener\Traits\FormTypeTrait;
 use CrudView\Listener\Traits\IndexTypeTrait;
 use CrudView\Listener\Traits\SidebarNavigationTrait;
@@ -17,6 +18,7 @@ use Crud\Listener\BaseListener;
 class ViewListener extends BaseListener
 {
     use CrudViewConfigTrait;
+    use DeprecatedConfigurationKeyTrait;
     use FormTypeTrait;
     use IndexTypeTrait;
     use SidebarNavigationTrait;

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -16,25 +16,31 @@ if ($this->exists('before_form')) {
     <?= $this->element('action-header') ?>
 
     <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl, 'type' => 'file', 'data-dirty-check' => $formEnableDirtyCheck]); ?>
-    <?= $this->CrudView->redirectUrl(); ?>
-    <div class="row">
-        <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
-            <?= $this->Form->inputs($fields, ['legend' => false]); ?>
-        </div>
-
-        <?php if ($formSidebarExists) : ?>
-            <div class="col-lg-2">
-                <?= $this->fetch('form.sidebar'); ?>
-            </div>
+        <?php if ($this->exists('form.after_create')) : ?>
+            <?= $this->fetch('form.after_create'); ?>
         <?php endif; ?>
-    </div>
-    <div class="row">
-        <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
-           <div class="form-group">
-                <?= $this->element('form/buttons') ?>
+        <?= $this->CrudView->redirectUrl(); ?>
+        <div class="row">
+            <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
+                <?= $this->Form->inputs($fields, ['legend' => false]); ?>
+            </div>
+
+            <?php if ($formSidebarExists) : ?>
+                <div class="col-lg-2">
+                    <?= $this->fetch('form.sidebar'); ?>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div class="row">
+            <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
+               <div class="form-group">
+                    <?= $this->element('form/buttons') ?>
+                </div>
             </div>
         </div>
-    </div>
+        <?php if ($this->exists('form.before_end')) : ?>
+            <?= $this->fetch('form.before_end'); ?>
+        <?php endif; ?>
     <?= $this->Form->end(); ?>
 </div>
 

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -3,6 +3,13 @@ $formSidebarExists = $this->exists('form.sidebar');
 if ($this->exists('form.before')) {
     echo $this->fetch('form.before');
 }
+if ($this->exists('before_form')) {
+    $template = 'The view block %s has been deprecated. Use %s instead.';
+    $message = sprintf($template, 'before_form', 'form.before');
+    trigger_error($message, E_USER_DEPRECATED);
+
+    echo $this->fetch('before_form');
+}
 ?>
 
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
@@ -34,5 +41,12 @@ if ($this->exists('form.before')) {
 <?php
 if ($this->exists('form.after')) {
     echo $this->fetch('form.after');
+}
+if ($this->exists('after_form')) {
+    $template = 'The view block %s has been deprecated. Use %s instead.';
+    $message = sprintf($template, 'after_form', 'form.before');
+    trigger_error($message, E_USER_DEPRECATED);
+
+    echo $this->fetch('after_form');
 }
 ?>

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -1,4 +1,5 @@
 <?= $this->fetch('before_form'); ?>
+<? $formSidebarExists = $this->exists('form.sidebar'); ?>
 
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
     <?= $this->element('action-header') ?>
@@ -6,18 +7,18 @@
     <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl, 'type' => 'file', 'data-dirty-check' => $enableDirtyCheck]); ?>
     <?= $this->CrudView->redirectUrl(); ?>
     <div class="row">
-        <div class="col-lg-<?= $this->exists('form.sidebar') ? '8' : '12' ?>">
+        <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
             <?= $this->Form->inputs($fields, ['legend' => false]); ?>
         </div>
 
-        <?php if ($this->exists('form.sidebar')) : ?>
+        <?php if ($formSidebarExists) : ?>
             <div class="col-lg-2">
                 <?= $this->fetch('form.sidebar'); ?>
             </div>
         <?php endif; ?>
     </div>
     <div class="row">
-        <div class="col-lg-<?= $this->exists('form.sidebar') ? '8' : '12' ?>">
+        <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
            <div class="form-group">
                 <?= $this->element('form/buttons') ?>
             </div>

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -1,5 +1,9 @@
-<?= $this->fetch('before_form'); ?>
-<? $formSidebarExists = $this->exists('form.sidebar'); ?>
+<?php
+$formSidebarExists = $this->exists('form.sidebar');
+if ($this->exists('form.before')) {
+    echo $this->fetch('form.before');
+}
+?>
 
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
     <?= $this->element('action-header') ?>
@@ -27,4 +31,8 @@
     <?= $this->Form->end(); ?>
 </div>
 
-<?= $this->fetch('after_form'); ?>
+<?php
+if ($this->exists('form.after')) {
+    echo $this->fetch('form.after');
+}
+?>

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -1,11 +1,11 @@
 <?php
 $formSidebarExists = $this->exists('form.sidebar');
-if ($this->exists('form.before')) {
-    echo $this->fetch('form.before');
+if ($this->exists('form.before_create')) {
+    echo $this->fetch('form.before_create');
 }
 if ($this->exists('before_form')) {
     $template = 'The view block %s has been deprecated. Use %s instead.';
-    $message = sprintf($template, 'before_form', 'form.before');
+    $message = sprintf($template, 'before_form', 'form.before_create');
     trigger_error($message, E_USER_DEPRECATED);
 
     echo $this->fetch('before_form');
@@ -39,12 +39,12 @@ if ($this->exists('before_form')) {
 </div>
 
 <?php
-if ($this->exists('form.after')) {
-    echo $this->fetch('form.after');
+if ($this->exists('form.after_end')) {
+    echo $this->fetch('form.after_end');
 }
 if ($this->exists('after_form')) {
     $template = 'The view block %s has been deprecated. Use %s instead.';
-    $message = sprintf($template, 'after_form', 'form.before');
+    $message = sprintf($template, 'after_form', 'form.after_end');
     trigger_error($message, E_USER_DEPRECATED);
 
     echo $this->fetch('after_form');

--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -8,7 +8,7 @@ if ($this->exists('form.before')) {
 <div class="<?= $this->CrudView->getCssClasses(); ?>">
     <?= $this->element('action-header') ?>
 
-    <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl, 'type' => 'file', 'data-dirty-check' => $enableDirtyCheck]); ?>
+    <?= $this->Form->create(${$viewVar}, ['role' => 'form', 'url' => $formUrl, 'type' => 'file', 'data-dirty-check' => $formEnableDirtyCheck]); ?>
     <?= $this->CrudView->redirectUrl(); ?>
     <div class="row">
         <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">

--- a/src/Template/Element/form/buttons.ctp
+++ b/src/Template/Element/form/buttons.ctp
@@ -1,6 +1,6 @@
 <div class="col pull-right">
     <?php
-        echo $this->Form->button($submitButtonText, ['class' => 'btn btn-primary', 'name' => '_save']);
+        echo $this->Form->button($formSubmitButtonText, ['class' => 'btn btn-primary', 'name' => '_save']);
 
         if (!empty($formSubmitExtraButtons)) {
             foreach ($formSubmitExtraButtons as $button) {

--- a/src/Template/Element/form/buttons.ctp
+++ b/src/Template/Element/form/buttons.ctp
@@ -1,15 +1,14 @@
 <div class="col pull-right">
     <?php
         echo $this->Form->button($submitButtonText, ['class' => 'btn btn-primary', 'name' => '_save']);
-        if (empty($disableExtraButtons)) {
-            if (!in_array('save_and_continue', $extraButtonsBlacklist)) {
-                echo $this->Form->button(__d('crud', 'Save & continue editing'), ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true]);
-            }
-            if (!in_array('save_and_create', $extraButtonsBlacklist)) {
-                echo $this->Form->button(__d('crud', 'Save & create new'), ['class' => 'btn btn-success', 'name' => '_add', 'value' => true]);
-            }
-            if (!in_array('back', $extraButtonsBlacklist)) {
-                echo $this->Html->link(__d('crud', 'Back'), ['action' => 'index'], ['class' => 'btn btn-default', 'role' => 'button', 'value' => true]);
+
+        if (!empty($formSubmitExtraButtons)) {
+            foreach ($formSubmitExtraButtons as $button) {
+                if ($button['type'] === 'button') {
+                    echo $this->Form->button($button['title'], $button['options']);
+                } elseif ($button['type'] === 'link') {
+                    echo $this->Html->link($button['title'], $button['url'], $button['options']);
+                }
             }
         }
     ?>


### PR DESCRIPTION
- Adds much-needed documentation. I consider anything documented stable, and all else refactorable/removable.
- Replaced the `after_form/before_form` view blocks with `form.after_end/form.before_create` viewblocks. The old ones will render but will trigger a deprecation notice.
- Added `form.after_create/form.before_end` viewblocks.
- Namespaced the `submit_button_text` and `enable_dirty_check` options with the word `form`. Also changed the variable in use. The old variables will still take affect but will emit a deprecation notice.
- Created a new `form_submit_extra_buttons` configuration key. This allows total control of the form submit buttons. The configuration keys `scaffold.disable_extra_buttons` and `scaffold.extra_buttons_blacklist` will still take effect but will emit a deprecation notice.