### PR TITLE
feat: add support for BootstrapUI Breadcrumbs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "cakephp/cakephp": "~3.0",
         "friendsofcake/crud": "*",
-        "friendsofcake/bootstrap-ui": "~1.0"
+        "friendsofcake/bootstrap-ui": "~1.2"
     },
     "require-dev": {
         "friendsofcake/cakephp-test-utilities": "dev-master"

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -30,6 +30,7 @@ Contents
    :maxdepth: 3
    :caption: General Configuration
 
+    Breadcrumbs <general-configuration/breadcrumbs>
     Site Title Options <general-configuration/site-title-options>
     Sidebar Navigation <general-configuration/sidebar-navigation>
     Utility Navigation <general-configuration/utility-navigation>

--- a/docs/general-configuration/breadcrumbs.rst
+++ b/docs/general-configuration/breadcrumbs.rst
@@ -1,0 +1,69 @@
+Breadcrumbs
+===========
+
+You can indicate the current page's location within a navigational hierarchy
+called a breadcrumb. CrudView does not output breadcrumbs by default, but they
+may be enabled via the ``scaffold.breadcrumbs`` configuration key.
+
+    Settings this configuration key to anything other than an array will
+    result in no breadcrumbs.
+
+Adding Breadcrumbs
+------------------
+
+The ``scaffold.breadcrumbs`` configuration key takes an array of
+``CrudView\Breadcrumb\Breadcrumb`` objects:
+
+.. code-block:: php
+
+    use CrudView\Breadcrumb\Breadcrumb;
+
+    $this->Crud->action()->config('scaffold.breadcrumbs', [
+        new BreadCrumb('Home'),
+    ]);
+
+By default, ``CrudView\Breadcrumb\Breadcrumb`` objects will output plain-text
+breadcrumb entries. However, they also take ``url`` and ``options`` arrays:
+
+.. code-block:: php
+
+    use CrudView\Breadcrumb\Breadcrumb;
+
+    $this->Crud->action()->config('scaffold.breadcrumbs', [
+        new BreadCrumb('Home', ['controller' => 'Posts', 'action' => 'index'], ['class' => 'derp']),
+    ]);
+
+Active Breadcrumb
+-----------------
+
+You may also set any given breadcrumb to "active" by either setting the
+``class`` option to 'active' or using a
+``CrudView\Breadcrumb\ActiveBreadCrumb`` object:
+
+.. code-block:: php
+
+    // Using the "class" option method:
+    use CrudView\Breadcrumb\Breadcrumb;
+
+    $this->Crud->action()->config('scaffold.breadcrumbs', [
+        new BreadCrumb('Home', '#', ['class' => 'active']),
+    ]);
+
+    // Using the ActiveBreadCrumb method:
+    use CrudView\Breadcrumb\ActiveBreadCrumb;
+
+    $this->Crud->action()->config('scaffold.breadcrumbs', [
+        new ActiveBreadCrumb('Home', '#'),
+    ]);
+
+Custom Layouts with Breadcrumbs
+-------------------------------
+
+Breadcrumbs are output in the ``layout`` portion of template rendering,
+outside of ``action`` template rendering. If you wish to change the layout but
+reuse the breadcrumb template logic, use the ``CrudView.breadcrumbs`` element
+like so:
+
+.. code-block:: php
+
+    <?= $this->element('breadcrumbs') ?>

--- a/src/Breadcrumb/ActiveBreadcrumb.php
+++ b/src/Breadcrumb/ActiveBreadcrumb.php
@@ -1,0 +1,22 @@
+<?php
+namespace CrudView\Breadcrumb;
+
+use CrudView\Breadcrumb\Breadcrumb;
+
+class ActiveBreadcrumb extends Breadcrumb
+{
+    /**
+     * @inheritdoc
+     */
+    public function __construct($title, $url = null, array $options = [])
+    {
+        if (!isset($options['class'])) {
+            $options['class'] = '';
+        }
+        $options['class'] = explode(' ', $options['class']);
+        $options['class'][] = 'active';
+        $options['class'] = trim(implode(' ', array_unique($options['class'])));
+
+        parent::__construct($title, $url, $options);
+    }
+}

--- a/src/Breadcrumb/Breadcrumb.php
+++ b/src/Breadcrumb/Breadcrumb.php
@@ -1,0 +1,84 @@
+<?php
+namespace CrudView\Breadcrumb;
+
+class Breadcrumb
+{
+    /**
+     * The content to be wrapped by `<li>` tags.
+     * If the specified $url is a link, then this will
+     * also be wrapped by `<a>` tags.
+     *
+     * @var string
+     **/
+    protected $title;
+
+    /**
+     * Cake-relative URL or array of URL parameters, or
+     * external URL (starts with http://)
+     *
+     * @var string|array|null
+     */
+    protected $url = null;
+
+    /**
+     * Array of options and HTML attributes.
+     *
+     * @var array
+     **/
+    protected $options = [];
+
+    /**
+     * Contains a breadcrumb entry
+     *
+     * @param string|array $title If provided as a string, it represents the title of the crumb.
+     * Alternatively, if you want to add multiple crumbs at once, you can provide an array, with each values being a
+     * single crumb. Arrays are expected to be of this form:
+     * - *title* The title of the crumb
+     * - *link* The link of the crumb. If not provided, no link will be made
+     * - *options* Options of the crumb. See description of params option of this method.
+     * @param string|array|null $url URL of the crumb. Either a string, an array of route params to pass to
+     * Url::build() or null / empty if the crumb does not have a link.
+     * @param array $options Array of options. These options will be used as attributes HTML attribute the crumb will
+     * be rendered in (a <li> tag by default). It accepts two special keys:
+     * - *innerAttrs*: An array that allows you to define attributes for the inner element of the crumb (by default, to
+     * the link)
+     * - *templateVars*: Specific template vars in case you override the templates provided.
+     * @return void
+     */
+    public function __construct($title, $url = null, array $options = [])
+    {
+        $this->title = $title;
+        $this->url = $url;
+        $this->options = $options;
+    }
+
+    /**
+     * Returns the menu item title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * Returns the menu item ur
+     *
+     * @return string|array|null
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Returns the menu item options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -85,6 +85,7 @@ class ViewListener extends BaseListener
         $controller = $this->_controller();
         $controller->set('actionConfig', $this->_action()->config());
         $controller->set('title', $this->_getPageTitle());
+        $controller->set('breadcrumbs', $this->_getBreadcrumbs());
         $associations = $this->associations;
         $controller->set(compact('associations'));
         $controller->set('fields', $this->_scaffoldFields($associations));
@@ -169,6 +170,18 @@ class ViewListener extends BaseListener
         }
 
         return sprintf('%s %s #%s: %s', $actionName, $controllerName, $primaryKeyValue, $displayFieldValue);
+    }
+
+    /**
+     * Get breadcrumns.
+     *
+     * @return array
+     */
+    protected function _getBreadcrumbs()
+    {
+        $action = $this->_action();
+
+        return $action->config('scaffold.breadcrumbs') ?: [];
     }
 
     /**

--- a/src/Template/Element/breadcrumbs.ctp
+++ b/src/Template/Element/breadcrumbs.ctp
@@ -1,0 +1,9 @@
+<?php
+if (empty($breadcrumbs)) {
+    return;
+}
+?>
+<?php foreach ($breadcrumbs as $breadcrumb): ?>
+    <?php $this->Breadcrumbs->add($breadcrumb->getTitle(), $breadcrumb->getUrl(), $breadcrumb->getOptions()); ?>
+<?php endforeach; ?>
+<?= $this->Breadcrumbs->render(); ?>

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -42,6 +42,7 @@
             <?php if ($disableSidebar) : ?>
                 <div class="col-sm-12">
                     <?= $this->Flash->render(); ?>
+                    <?= $this->element('breadcrumbs') ?>
                     <?= $this->fetch('content'); ?>
                     <?= $this->fetch('action_link_forms'); ?>
                 </div>
@@ -51,6 +52,7 @@
                 </div>
                 <div class="col-xs-12 col-sm-10 col-lg-10">
                     <?= $this->Flash->render(); ?>
+                    <?= $this->element('breadcrumbs') ?>
                     <?= $this->fetch('content'); ?>
                     <?= $this->fetch('action_link_forms'); ?>
                 </div>

--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -92,6 +92,9 @@ class CrudView extends View
         ]);
         $this->loadHelper('Flash', ['className' => 'BootstrapUI.Flash']);
         $this->loadHelper('Paginator', ['className' => 'BootstrapUI.Paginator']);
+        if (class_exists('\Cake\View\Helper\BreadcrumbsHelper')) {
+            $this->loadHelper('Breadcrumbs', ['className' => 'BootstrapUI.Breadcrumbs']);
+        }
 
         $this->loadHelper('CrudView.CrudView');
         $this->loadHelper('BootstrapUI.Flash');


### PR DESCRIPTION
- upgrade to at least bootstrap-ui 1.2
- pull blockquotes from `scaffold.breadcrumbs` configuration key
- introduce Breadcrumb and ActiveBreadcrumb classes
- add docs for all blockquote-related functionality