### PR TITLE
SearchViewListener: filter collection

### DIFF
--- a/docs/_partials/pages/index/filters.rst
+++ b/docs/_partials/pages/index/filters.rst
@@ -28,11 +28,40 @@ to be installed and filters configured for your model using the search manager.
                 // The search behavior collection to use. Default "default".
                 'collection' => 'default',
 
-                // Fields config for generation filter inputs. If `null` the field
-                // inputs will be derived based on filter collection. Default `null``.
-                'fields' => null
+                // Config for generating filter controls. If `null` the
+                // filter controls will be derived based on filter collection.
+                // You can use "form" key in filter config to specify control options.
+                // Default `null`.
+                'fields' => [
+                    // Key should be the filter name.
+                    'filter_1 => [
+                        // Any option which you can use Form::control() options.
+                    ],
+                    // Control options for other filters.
+                ]
             ]);
 
             $this->Crud->execute();
         }
     }
+
+Here's an e.g. of how configure filter controls options through search manager itself::
+
+.. code-block:: php
+
+    <?php
+    // Samples::initialize()
+    $this->searchManager()
+        ->useCollection('backend')
+        ->add('q', 'Search.Like', [
+            'field' => ['title', 'body'],
+            'form' => [
+                'data-foo' => 'bar'
+            ]
+        ])
+        ->add('category_id', 'Search.Value', [
+            'form' => [
+                'type' => 'select',
+                'class' => 'no-selectize'
+            ]
+        ]);

--- a/docs/_partials/pages/index/filters.rst
+++ b/docs/_partials/pages/index/filters.rst
@@ -14,9 +14,12 @@ to be installed and filters configured for your model using the search manager.
             $this->Crud->addListener('Crud.Crud');
             $this->Crud->addListener('Crud.ViewSearch', [
                 // Indicates whether is listener is enabled.
-                'enable' => true,
+                'enabled' => true,
 
                 // Whether to use auto complete for select fields. Default `true`.
+                // This requires you have `Crud.Lookup` action enabled for that
+                // related model's controller.
+                // http://crud.readthedocs.io/en/latest/actions/lookup.html
                 'autocomplete' => true,
 
                 // Whether to use selectize for select fields. Default `true`.

--- a/docs/_partials/pages/index/filters.rst
+++ b/docs/_partials/pages/index/filters.rst
@@ -1,2 +1,35 @@
 Index Filters
 -------------
+
+The ``ViewSearch`` listener generates filter inputs for filtering records on your
+index action. It requries `friendsofcake/search <https://packagist.org/packages/friendsofcake/search>`
+to be installed and filters configured for your model using the search manager.
+
+.. code-block:: php
+
+    <?php
+    class SamplesController extends AppController {
+
+        public function index() {
+            $this->Crud->addListener('Crud.Crud');
+            $this->Crud->addListener('Crud.ViewSearch', [
+                // Indicates whether is listener is enabled.
+                'enable' => true,
+
+                // Whether to use auto complete for select fields. Default `true`.
+                'autocomplete' => true,
+
+                // Whether to use selectize for select fields. Default `true`.
+                'selectize' => true,
+
+                // The search behavior collection to use. Default "default".
+                'collection' => 'default',
+
+                // Fields config for generation filter inputs. If `null` the field
+                // inputs will be derived based on filter collection. Default `null``.
+                'fields' => null
+            ]);
+
+            $this->Crud->execute();
+        }
+    }

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -46,13 +46,14 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
                     'CrudView.View',
                     'Crud.Redirect',
                     'Crud.RelatedModels',
-                    // If you need searching
+                    // If you need searching. Generally it's better to load these
+                    // only in the controller for which you need searching.
                     'Crud.Search',
                     'CrudView.ViewSearch',
                 ]
             ]);
         }
-        
+
         /**
          * Before render callback.
          *
@@ -65,7 +66,7 @@ If you haven't configured the CRUD plugin already, add the following lines to yo
             if ($this->viewBuilder()->className() === null) {
                 $this->viewBuilder()->className('CrudView\View\CrudView');
             }
-            
+
             // For CakePHP 3.0
             /*
             if ($this->viewClass === null) {

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -18,6 +18,8 @@ class ViewSearchListener extends BaseListener
         'enabled' => null,
         'autocomplete' => true,
         'selectize' => true,
+        'collection' => 'default',
+        'fields' => null
     ];
 
     /**
@@ -80,12 +82,12 @@ class ViewSearchListener extends BaseListener
         if (method_exists($table, 'searchConfiguration')) {
             $filters = $table->searchConfiguration();
         } else {
-            $filters = $table->searchManager();
+            $filters = $table->searchManager()->useCollection($config['collection']);
         }
 
         $fields = [];
         $schema = $table->getSchema();
-        $config = $this->_config;
+        $config = $this->getConfig();
 
         foreach ($filters->all() as $filter) {
             if ($filter->getConfig('form') === false) {
@@ -95,7 +97,7 @@ class ViewSearchListener extends BaseListener
             $field = $filter->name();
             $input = [];
 
-            $filterFormConfig = $filter->config();
+            $filterFormConfig = $filter->getConfig();
             if (!empty($filterFormConfig['form'])) {
                 $input = $filterFormConfig['form'];
             }
@@ -105,6 +107,10 @@ class ViewSearchListener extends BaseListener
                 'required' => false,
                 'type' => 'text'
             ];
+
+            if (substr($field, -3) === '_id' && $field !== '_id') {
+                $input['type'] = 'select';
+            }
 
             $input['value'] = $request->getQuery($field);
 

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -12,6 +12,15 @@ class ViewSearchListener extends BaseListener
     /**
      * Default configuration
      *
+     * ### Options
+     *
+     * - `enable`: Indicates whether is listener is enabled.
+     * - `autocomplete`: Whether to use auto complete for select fields. Default `true`.
+     * - `autocomplete`: Whether to use selectize for select fields. Default `true`.
+     * - `collection`: The search behavior collection to use. Default "default".
+     * - `fields`: Fields config for generation filter inputs. If `null` the
+     *   field inputs will be derived based on filter collection. Default `null``.
+     *
      * @var array
      */
     protected $_defaultConfig = [
@@ -23,7 +32,7 @@ class ViewSearchListener extends BaseListener
     ];
 
     /**
-     * implementedEvents
+     * Events this listerner is interested in.
      *
      * @return array
      */
@@ -35,7 +44,7 @@ class ViewSearchListener extends BaseListener
     }
 
     /**
-     * afterPaginate
+     * After paginate event callback.
      *
      * Only after a crud paginate call does this listener do anything. So listen
      * for that
@@ -60,7 +69,7 @@ class ViewSearchListener extends BaseListener
     }
 
     /**
-     * [fields description]
+     * Get field options for search filter inputs.
      *
      * @return array
      */
@@ -70,7 +79,7 @@ class ViewSearchListener extends BaseListener
     }
 
     /**
-     * [_deriveFields description]
+     * Derive field options for search filter inputs based on filter collection.
      *
      * @return array
      */

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -14,7 +14,7 @@ class ViewSearchListener extends BaseListener
      *
      * ### Options
      *
-     * - `enable`: Indicates whether is listener is enabled.
+     * - `enabled`: Indicates whether is listener is enabled.
      * - `autocomplete`: Whether to use auto complete for select fields. Default `true`.
      * - `selectize`: Whether to use selectize for select fields. Default `true`.
      * - `collection`: The search behavior collection to use. Default "default".

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -16,7 +16,7 @@ class ViewSearchListener extends BaseListener
      *
      * - `enable`: Indicates whether is listener is enabled.
      * - `autocomplete`: Whether to use auto complete for select fields. Default `true`.
-     * - `autocomplete`: Whether to use selectize for select fields. Default `true`.
+     * - `selectize`: Whether to use selectize for select fields. Default `true`.
      * - `collection`: The search behavior collection to use. Default "default".
      * - `fields`: Fields config for generation filter inputs. If `null` the
      *   field inputs will be derived based on filter collection. Default `null``.

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -104,14 +104,7 @@ class ViewSearchListener extends BaseListener
             }
 
             $field = $filter->name();
-            $input = [];
-
-            $filterFormConfig = $filter->getConfig();
-            if (!empty($filterFormConfig['form'])) {
-                $input = $filterFormConfig['form'];
-            }
-
-            $input += [
+            $input = [
                 'label' => Inflector::humanize(preg_replace('/_id$/', '', $field)),
                 'required' => false,
                 'type' => 'text'
@@ -119,6 +112,11 @@ class ViewSearchListener extends BaseListener
 
             if (substr($field, -3) === '_id' && $field !== '_id') {
                 $input['type'] = 'select';
+            }
+
+            $filterFormConfig = $filter->getConfig('form');
+            if (!empty($filterFormConfig)) {
+                $input = $filterFormConfig + $input;
             }
 
             $input['value'] = $request->getQuery($field);

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -18,8 +18,9 @@ class ViewSearchListener extends BaseListener
      * - `autocomplete`: Whether to use auto complete for select fields. Default `true`.
      * - `selectize`: Whether to use selectize for select fields. Default `true`.
      * - `collection`: The search behavior collection to use. Default "default".
-     * - `fields`: Fields config for generation filter inputs. If `null` the
-     *   field inputs will be derived based on filter collection. Default `null``.
+     * - `fields`: Config for generating filter controls. If `null` the
+     *   filter controls will be derived based on filter collection. You can use
+     *   "form" key in filter config to specify control options. Default `null`.
      *
      * @var array
      */


### PR DESCRIPTION
What this PR does:
- Adds ability to specify the filter collection to use.
- ~~Adds `beforePaginate` callback which automatically applies `search` finder to the query.~~

Referring to changes #171:

> scaffold.index_filters = null|false: default, disable filters

I don't think not showing any filters is a good default. If you don't want any filter inputs to be generated one should just not load the listener or disable it.

> scaffold.index_filters = true: auto-import default search collection
> scaffold.index_filters = 'crud': auto-import a specific search collection

The `collection` option I added to the listener takes care of this.

> scaffold.index_filters = []: specific array of filter settings

The listener already has support for `fields` option to achieve the same. I have documented it.
