### PR TITLE
Change "ready" handler usage.

### DIFF
--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -1,4 +1,4 @@
-$(document).on('ready', function() {
+$(function() {
 
     var bulkActionForm = $('.bulk-actions');
     if (bulkActionForm.length) {


### PR DESCRIPTION
`$(document).on("ready", fn)` style usage has been removed in jquery 3.
See https://jquery.com/upgrade-guide/3.0/#deprecated-document-ready-handlers-other-than-jquery-function