### PR TITLE
Template selection options not working

### DIFF
--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -201,7 +201,7 @@ class CrudView extends View
             $this->subDir = null;
             $this->templatePath = 'Scaffold';
 
-            return parent::_getViewFileName($this->template);
+            return parent::_getViewFileName($name);
         }
     }
 }

--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -206,6 +206,5 @@ class CrudView extends View
         } catch (MissingTemplateException $exception) {
             return parent::_getViewFileName($name);
         }
-
     }
 }

--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -200,8 +200,12 @@ class CrudView extends View
         } catch (MissingTemplateException $exception) {
             $this->subDir = null;
             $this->templatePath = 'Scaffold';
-
+        }
+        try {
+            return parent::_getViewFileName($this->template);
+        } catch (MissingTemplateException $exception) {
             return parent::_getViewFileName($name);
         }
+
     }
 }


### PR DESCRIPTION
Using $this->template here is just plain wrong!

You want to use the $name argument here too of course!

Using $this->template breaks custom actions like so:

```
function beforeFilter($event) {
  $this->Crud->mapAction('account', [
    'className' => 'Crud.View',
    'view' => 'view'
  ]);
}

function account() {
  return $this->Crud->execute();
}
```
If there should be a valid case to use $this->template too, we need another try/catch block i suppose.