### PR TITLE
Fix span tag generation.

### DIFF
--- a/src/Template/Element/action-groups.ctp
+++ b/src/Template/Element/action-groups.ctp
@@ -17,10 +17,10 @@ foreach ($groups as $key => $group) {
 <?php foreach ($groups as $key => $group) : ?>
     <div class='btn-group'>
         <?= $this->Html->link(
-            sprintf("%s %s", $key, $this->Html->tag('span', null, ['class' => 'caret'])),
+            sprintf("%s %s", $key, $this->Html->tag('span', '', ['class' => 'caret'])),
             '#',
-            ['class' => 'btn btn-default dropdown-toggle', 'escape' => false, 'data-toggle' => 'dropdown', 'aria-haspopup' => true, 'aria-expanded' => false]);
-        ?>
+            ['class' => 'btn btn-default dropdown-toggle', 'escape' => false, 'data-toggle' => 'dropdown', 'aria-haspopup' => true, 'aria-expanded' => false]
+        ) ?>
         <ul class="dropdown-menu pull-right">
             <?php foreach ($group as $action => $config) : ?>
                 <?php $subaction = is_array($config) ? $action : $config; ?>


### PR DESCRIPTION
If you pass `null` as second param to HtmlHelper::tag() it will generate only opening tag.