### PR TITLE
Add missing parameter

### DIFF
--- a/docs/_partials/fields/formatter-callable.rst
+++ b/docs/_partials/fields/formatter-callable.rst
@@ -37,7 +37,7 @@ only configure the settings for one or two.
     $action = $this->Crud->action();
     $action->config('scaffold.field_settings', [
         'published_time' => [
-            'formatter' => function ($name, Time $value) {
+            'formatter' => function ($name, Time $value, Entity $entity) {
                 return $value->nice() . sprintf(' (Approved by %s)', $entity->approver->name);
             }
         ],


### PR DESCRIPTION
Maybe one should talk about the typehinting, as it's optional - for now it's in the second example while missing in the first. Hopefully that's obvious enough...