### PR TITLE
Move content of "form.before_end" block above buttons

### DIFF
--- a/src/Template/Element/form.ctp
+++ b/src/Template/Element/form.ctp
@@ -1,6 +1,4 @@
 <?php
-use Cake\Utility\Text;
-
 $formSidebarExists = $this->exists('form.sidebar');
 if ($this->exists('form.before_create')) {
     echo $this->fetch('form.before_create');
@@ -30,6 +28,9 @@ if ($this->exists('form.before_create')) {
                 </div>
             <?php endif; ?>
         </div>
+        <?php if ($this->exists('form.before_end')) : ?>
+            <?= $this->fetch('form.before_end'); ?>
+        <?php endif; ?>
         <div class="row">
             <div class="col-lg-<?= $formSidebarExists ? '8' : '12' ?>">
                 <div class="form-group">
@@ -37,9 +38,6 @@ if ($this->exists('form.before_create')) {
                 </div>
             </div>
         </div>
-        <?php if ($this->exists('form.before_end')) : ?>
-            <?= $this->fetch('form.before_end'); ?>
-        <?php endif; ?>
     <?= $this->Form->end(); ?>
 </div>
 


### PR DESCRIPTION
If you are adding content before form ends it's most likely to contain input tags which you would want to be shown above the save buttons.