### PR TITLE
Exclude scaffold settings from actions

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -445,7 +445,7 @@ class ViewListener extends BaseListener
             'method' => $method,
             'options' => array_diff_key(
                 $config,
-                array_flip(['method', 'scope', 'className', 'link_title', 'messages', 'url'])
+                array_flip(['method', 'scope', 'className', 'link_title', 'messages', 'url', 'scaffold'])
             )
         ];
         if (!empty($config['callback'])) {


### PR DESCRIPTION
Prevents `array to string` notices.