### PR TITLE
feat: Add DashboardAction

### DIFF
--- a/docs/_partials/pages/dashboard/elements.rst
+++ b/docs/_partials/pages/dashboard/elements.rst
@@ -1,0 +1,16 @@
+Available Elements
+------------------
+
+All the *CrudView* templates are built from several elements that can be
+overridden by creating them in your own ``src/Template/Element`` folder. The
+following sections will list all the elements that can be overridden for each
+type of action.
+
+In general, if you want to override a template, it is a good idea to copy the
+original implementation from
+``vendor/friendsofcake/crud-view/src/Template/Element``
+
+action-header
+  Create ``src/Template/Element/action-header.ctp`` to have full control over
+  what is displayed at the top of the page. This is shared across all page
+  types.

--- a/docs/_partials/pages/dashboard/viewblocks.rst
+++ b/docs/_partials/pages/dashboard/viewblocks.rst
@@ -1,0 +1,7 @@
+Available Viewblocks
+--------------------
+
+The following custom view blocks are available for use within forms:
+
+- ``dashboard.before``: Rendered before the entire dashboard is rendered.
+- ``dashboard.after``: Rendered after the entire dashboard is rendered.

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -35,6 +35,14 @@ Contents
     Sidebar Navigation <general-configuration/sidebar-navigation>
     Utility Navigation <general-configuration/utility-navigation>
 
+.. _dashboard-pages-docs:
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Dashboard Pages
+
+   Customizing the Dashboard <dashboard-pages/customizing-the-dashboard-page>
+
 .. _index-pages-docs:
 
 .. toctree::

--- a/docs/dashboard-pages/customizing-the-dashboard-page.rst
+++ b/docs/dashboard-pages/customizing-the-dashboard-page.rst
@@ -1,0 +1,136 @@
+Customizing the Dashboard Page
+==============================
+
+The "dashboard" can be used to display a default landing page for CrudView-powered
+admin sites. It is made of several ``\Cake\View\Cell``
+instances, and can be extended to display items other than what is shipped with CrudView.
+
+To use the "Dashboard", the custom ``DashboardAction`` needs to be mapped:
+
+.. code-block:: php
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->Crud->mapAction('dashboard', 'CrudView.Dashboard');
+    }
+
+Browsing to this mapped action will result in a blank page. To customize it, a
+``\CrudView\Dashboard\Dashboard`` can be configured on the ``scaffold.dashboard`` key:
+
+.. code-block:: php
+
+    public function dashboard()
+    {
+        $dashboard = new \CrudView\Dashboard\Dashboard();
+        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
+        return $this->Crud->execute();
+    }
+
+
+The ``\CrudView\Dashboard\Dashboard`` instance takes two arguments:
+
+- ``title``: The title for the dashboard view. Defaults to ``Dashboard``.
+- ``columns`` A number of columns to display on the view. Defaults to ``1``.
+
+.. code-block:: php
+
+    public function dashboard()
+    {
+        // setting both the title and the number of columns
+        $dashboard = new \CrudView\Dashboard\Dashboard(__('Site Administration'), 12);
+        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
+        return $this->Crud->execute();
+    }
+
+Adding Cells to the Dashboard
+-------------------------------
+
+Any number of cells may be added to the Dashboard. All cells *must* extend the
+``\Cake\View\Cell`` class.
+
+Cells can be added via the ``Dashboard::addToColumn()`` method. It takes a cell
+instance and a column number as arguments.
+
+.. code-block:: php
+
+    // assuming the `CellTrait` is in use, we can generate a cell via `$this->cell()`
+    $someCell = $this->cell('SomeCell');
+    $dashboard = new \CrudView\Dashboard\Dashboard(__('Site Administration'), 2);
+
+    // add to the first column
+    $dashboard->addToColumn($someCell);
+
+    // configure the column to add to
+    $dashboard->addToColumn($someCell, 2);
+
+CrudView ships with the ``DashboardTable`` cell by default.
+
+CrudView.DashboardTable
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This can be used to display links to items in your application or offiste.
+
+.. code-block:: php
+
+    public function dashboard()
+    {
+        // setting both the title and the number of columns
+        $dashboard = new \CrudView\Dashboard\Dashboard(__('Site Administration'), 1);
+        $dashboard->addToColumn($this->cell('CrudView.DashboardTable', [
+            'title' => 'Important Links'
+        ]));
+
+        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
+        return $this->Crud->execute();
+    }
+
+In the above example, only a title to the ``DashboardTable``, which will
+show a single subheading for your Dashboard.
+
+In addition to showing a title, it is also possible to show a list of links. This can
+be done by adding a ``links`` key with an array of ``LinkItem`` objects as the value.
+Links containing urls for external websites will open in a new window by default. 
+
+.. code-block:: php
+
+    public function dashboard()
+    {
+        // setting both the title and the number of columns
+        $dashboard = new \CrudView\Dashboard\Dashboard(__('Site Administration'), 1);
+        $dashboard->addToColumn($this->cell('CrudView.DashboardTable', [
+            'title' => 'Important Links',
+            'links' => [
+                new LinkItem('Example', 'https://example.com', ['target' => '_blank']),
+            ],
+        ]));
+
+        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
+        return $this->Crud->execute();
+    }
+
+There is also a special kind of ``LinkItem`` called an ``ActionLinkItem``. This
+has a fourth argument is an array of ``LinkItem`` objects. It can be used to show
+embedded action links on the same row.
+
+.. code-block:: php
+
+    public function dashboard()
+    {
+        $dashboard = new \CrudView\Dashboard\Dashboard(__('Site Administration'), 1);
+        $dashboard->addToColumn($this->cell('CrudView.DashboardTable', [
+            'title' => 'Important Links',
+            'links' => [
+                new ActionLinkItem('Posts', ['controller' => 'Posts'], [], [
+                    new LinkItem('Add', ['controller' => 'Posts', 'action' => 'add']),
+                ]),
+            ],
+        ]));
+
+        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
+        return $this->Crud->execute();
+    }
+
+.. include:: /_partials/pages/dashboard/viewblocks.rst
+.. include:: /_partials/pages/dashboard/elements.rst

--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -1,0 +1,43 @@
+<?php
+namespace CrudView\Action;
+
+use CrudView\Dashboard\Dashboard;
+use Crud\Action\BaseAction;
+use Crud\Traits\ViewTrait;
+
+class DashboardAction extends BaseAction
+{
+    use ViewTrait;
+
+    protected $_defaultConfig = [
+        'enabled' => true,
+        'view' => null,
+    ];
+
+    /**
+     * HTTP GET handler
+     *
+     * @return void|\Cake\Network\Response
+     */
+    protected function _get()
+    {
+        $pageTitle = $this->getConfig('scaffold.page_title', __d('CrudView', 'Dashboard'));
+        $this->setConfig('scaffold.page_title', $pageTitle);
+        $this->setConfig('scaffold.autoFields', false);
+        $this->setConfig('scaffold.fields', ['dashboard']);
+        $this->setConfig('scaffold.actions', []);
+
+        $dashboard = $this->getConfig('scaffold.dashboard', new Dashboard($pageTitle));
+        $subject = $this->_subject([
+            'success' => true,
+            'dashboard' => $dashboard,
+        ]);
+
+        $this->_trigger('beforeRender', $subject);
+
+        $controller = $this->_controller();
+        $controller->set('dashboard', $subject->dashboard);
+        $controller->set('viewVar', 'dashboard');
+        $controller->set('title', $subject->dashboard->get('title'));
+    }
+}

--- a/src/Dashboard/Dashboard.php
+++ b/src/Dashboard/Dashboard.php
@@ -1,0 +1,86 @@
+<?php
+namespace CrudView\Dashboard;
+
+use Cake\Datasource\EntityTrait;
+use Cake\View\Cell;
+use InvalidArgumentException;
+
+class Dashboard
+{
+    use EntityTrait;
+
+    /**
+     * Constructor
+     *
+     * @param string $title The name of the group
+     * @param int $columns Number of columns
+     */
+    public function __construct($title = null, $columns = 1)
+    {
+        if ($title === null) {
+            $title = __d('CrudView', 'Dashboard');
+        }
+
+        $this->set('title', $title);
+        $this->set('children', []);
+        $this->set('columns', $columns);
+    }
+
+    /**
+     * Returns the children from a given column
+     *
+     * @param int $column a column number
+     * @return array
+     */
+    public function getColumnChildren($column)
+    {
+        $children = $this->get('children');
+        if (isset($children[$column])) {
+            return $children[$column];
+        }
+
+        return [];
+    }
+
+    /**
+     * Adds a Cell to a given column
+     *
+     * @param Cell $module instance of Cell
+     * @param int $column a column number
+     * @return $this
+     */
+    public function addToColumn(Cell $module, $column = 1)
+    {
+        $children = $this->get('children');
+        $children[$column][] = $module;
+        $this->set('children', $children);
+
+        return $this;
+    }
+
+    /**
+     * columns property setter
+     *
+     * @param int $value A column count
+     * @return int
+     * @throws \InvalidArgumentException the column count is invalid
+     */
+    protected function _setColumns($value)
+    {
+        $columnMap = [
+            1 => 12,
+            2 => 6,
+            3 => 4,
+            4 => 3,
+            6 => 2,
+            12 => 1,
+        ];
+        if (!in_array($value, [1, 2, 3, 4, 6, 12])) {
+            throw new InvalidArgumentException('Valid columns value must be one of [1, 2, 3, 4, 6, 12]');
+        }
+
+        $this->set('columnClass', sprintf('col-md-%d', $columnMap[$value]));
+
+        return $value;
+    }
+}

--- a/src/Dashboard/Module/ActionLinkItem.php
+++ b/src/Dashboard/Module/ActionLinkItem.php
@@ -1,0 +1,48 @@
+<?php
+namespace CrudView\Dashboard\Module;
+
+use Cake\Collection\Collection;
+use Cake\Utility\Hash;
+use InvalidArgumentException;
+
+class ActionLinkItem extends LinkItem
+{
+    /**
+     * Array of LinkItems.
+     *
+     * @var array
+     **/
+    protected $actions = [];
+
+    /**
+     * Constructor
+     *
+     * @param string|array $title The content to be wrapped by `<a>` tags.
+     *   Can be an array if $url is null. If $url is null, $title will be used as both the URL and title.
+     * @param string|array|null $url Cake-relative URL or array of URL parameters, or
+     *   external URL (starts with http://)
+     * @param array $options Array of options and HTML attributes.
+     * @param array $actions Array of ActionItems
+     */
+    public function __construct($title, $url, $options = [], array $actions = [])
+    {
+        parent::__construct($title, $url, $options);
+        $this->set('actions', $actions);
+    }
+
+    /**
+     * options property setter
+     *
+     * @param array $actions Array of options and HTML attributes.
+     * @return array
+     */
+    protected function _setActions($actions)
+    {
+        return (new Collection($actions))->map(function ($value) {
+            $options = (array)$value->get('options') + ['class' => ['btn btn-default']];
+            $value->set('options', $options);
+
+            return $value;
+        })->toArray();
+    }
+}

--- a/src/Dashboard/Module/LinkItem.php
+++ b/src/Dashboard/Module/LinkItem.php
@@ -1,0 +1,103 @@
+<?php
+namespace CrudView\Dashboard\Module;
+
+use Cake\Datasource\EntityTrait;
+use Cake\Utility\Hash;
+use InvalidArgumentException;
+
+class LinkItem
+{
+    use EntityTrait;
+
+    /**
+     * The content to be wrapped by `<a>` tags.
+     *
+     * @var string
+     **/
+    protected $title;
+
+    /**
+     * Cake-relative URL or array of URL parameters, or
+     * external URL (starts with http://)
+     *
+     * @var string|array|null
+     */
+    protected $url = null;
+
+    /**
+     * Array of options and HTML attributes.
+     *
+     * @var array
+     **/
+    protected $options = [];
+
+    /**
+     * Constructor
+     *
+     * @param string|array $title The content to be wrapped by `<a>` tags.
+     *   Can be an array if $url is null. If $url is null, $title will be used as both the URL and title.
+     * @param string|array|null $url Cake-relative URL or array of URL parameters, or
+     *   external URL (starts with http://)
+     * @param array $options Array of options and HTML attributes.
+     */
+    public function __construct($title, $url, $options = [])
+    {
+        $this->set('title', $title);
+        $this->set('url', $url);
+        $this->set('options', $options);
+    }
+
+    /**
+     * title property setter
+     *
+     * @param string|array|null $title A title for the link
+     * @return string
+     */
+    protected function _setTitle($title)
+    {
+        if (empty($title)) {
+            throw new InvalidArgumentException('Missing title for LinkItem action');
+        }
+
+        return $title;
+    }
+    /**
+     * url property setter
+     *
+     * @param string|array|null $url Cake-relative URL or array of URL parameters, or
+     *   external URL (starts with http://)
+     * @return string|array
+     */
+    protected function _setUrl($url)
+    {
+        if ($url === null || empty($url)) {
+            throw new InvalidArgumentException('Invalid url specified for LinkItem');
+        }
+
+        return $url;
+    }
+
+    /**
+     * options property setter
+     *
+     * @param array $options Array of options and HTML attributes.
+     * @return string|array
+     */
+    protected function _setOptions($options)
+    {
+        if (empty($options)) {
+            $options = [];
+        }
+
+        $url = $this->get('url');
+        if (!is_array($url)) {
+            $isHttp = substr($url, 0, 7) === 'http://';
+            $isHttps = substr($url, 0, 8) === 'https://';
+            if ($isHttp || $isHttps) {
+                $options += ['target' => '_blank'];
+            }
+        }
+
+        return $options;
+    }
+}

--- a/src/Listener/Traits/IndexTypeTrait.php
+++ b/src/Listener/Traits/IndexTypeTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace CrudView\Listener\Traits;
 
+use Crud\Action\IndexAction;
+
 trait IndexTypeTrait
 {
     /**
@@ -10,6 +12,10 @@ trait IndexTypeTrait
      */
     public function beforeRenderIndexType()
     {
+        if (!($this->_action() instanceof IndexAction)) {
+            return;
+        }
+
         $controller = $this->_controller();
         $controller->set('indexFinderScopes', $this->_getIndexFinderScopes());
         $controller->set('indexFormats', $this->_getIndexFormats());

--- a/src/Template/Cell/DashboardTable/display.ctp
+++ b/src/Template/Cell/DashboardTable/display.ctp
@@ -1,0 +1,22 @@
+<?php if (!empty($title)) :?>
+    <h3><?= $title ?></h3>
+<?php endif; ?>
+
+<?php if (!empty($links)) : ?>
+<table class="table">
+    <tbody>
+        <?php foreach ($links as $link): ?>
+        <tr>
+            <td><?= $this->Html->link($link->get('title'), $link->get('url'), $link->get('options')) ?></td>
+            <?php if ($link->get('actions')) : ?>
+            <td class="actions">
+                <?php foreach ($link->get('actions') as $action) : ?>
+                    <?= $this->Html->link($action->get('title'), $action->get('url'), $action->get('options')) ?>
+                <?php endforeach; ?>
+            </td>
+            <?php endif; ?>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif; ?>

--- a/src/Template/Scaffold/dashboard.ctp
+++ b/src/Template/Scaffold/dashboard.ctp
@@ -1,0 +1,16 @@
+<?= $this->fetch('dashboard.before'); ?>
+
+<div class="<?= $this->CrudView->getCssClasses(); ?>">
+    <?= $this->element('action-header') ?>
+    <div class="row">
+        <?php foreach (range(1, $dashboard->get('columns')) as $columnNumber): ?>
+            <div class="<?= $dashboard->get('columnClass') ?>">
+                <?php foreach ($dashboard->getColumnChildren($columnNumber) as $module) : ?>
+                    <?= $module ?>
+                <?php endforeach; ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>
+
+<?= $this->fetch('dashboard.after'); ?>

--- a/src/View/Cell/DashboardTableCell.php
+++ b/src/View/Cell/DashboardTableCell.php
@@ -1,0 +1,33 @@
+<?php
+namespace CrudView\View\Cell;
+
+use Cake\View\Cell;
+
+/**
+ * DashboardTable cell
+ */
+class DashboardTableCell extends Cell
+{
+    /**
+     * Default display method.
+     *
+     * If the first argument is an array, it will replace the second
+     * `$links` argument and `$title` will be set to an empty string.
+     *
+     * @param string|array $title A title to display
+     * @param array $links A array of LinkItem objects
+     * @return void
+     */
+    public function display($title, array $links = [])
+    {
+        if (is_array($title)) {
+            $links = $title;
+            $title = '';
+        }
+
+        $this->set('title', $title);
+        if (!empty($links)) {
+            $this->set('links', $links);
+        }
+    }
+}

--- a/src/View/CrudView.php
+++ b/src/View/CrudView.php
@@ -60,11 +60,9 @@ class CrudView extends View implements EventListenerInterface
     /**
      * Handler for View.beforeLayout event.
      *
-     * @param \Cake\Event\Event $event The View.beforeLayout event
-     * @param string $layoutFileName Layout filename.
      * @return void
      */
-    public function beforeLayout(Event $event, $layoutFileName)
+    public function beforeLayout()
     {
         $this->_loadAssets();
     }

--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -121,7 +121,7 @@ class CrudViewHelper extends Helper
      * @param string $field Name of field.
      * @param mixed $value The value that the field should have within related data.
      * @param array $options Options array.
-     * @return string formatted value
+     * @return array|bool|null|int|string
      */
     public function introspect($field, $value, array $options = [])
     {
@@ -249,7 +249,7 @@ class CrudViewHelper extends Helper
      * Format display field value.
      *
      * @param string $value Display field value.
-     * @param array $options Field options.
+     * @param array $options Options array.
      * @return string
      */
     public function formatDisplayField($value, array $options)

--- a/tests/TestCase/Dashboard/DashboardTest.php
+++ b/tests/TestCase/Dashboard/DashboardTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace CrudView\Test\TestCase\Dashboard;
+
+use Cake\TestSuite\TestCase;
+use CrudView\Dashboard\Dashboard;
+use CrudView\View\Cell\DashboardTableCell;
+
+/**
+ * DashboardTest class
+ */
+class DashboardTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $dashboard = new Dashboard;
+        $expected = __d('CrudView', 'Dashboard');
+        $this->assertEquals($expected, $dashboard->get('title'));
+
+        $expected = [];
+        $this->assertEquals($expected, $dashboard->get('children'));
+
+        $expected = 1;
+        $this->assertEquals($expected, $dashboard->get('columns'));
+
+        $dashboard = new Dashboard('Test Title');
+        $expected = 'Test Title';
+        $this->assertEquals($expected, $dashboard->get('title'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Valid columns value must be one of [1, 2, 3, 4, 6, 12]
+     */
+    public function testInvalidConstruct()
+    {
+        $dashboard = new Dashboard(null, 0);
+    }
+
+    public function testColumnChildren()
+    {
+        $dashboard = new Dashboard;
+        $expected = [];
+        $this->assertEquals($expected, $dashboard->getColumnChildren(1));
+
+        $cell = new DashboardTableCell;
+        $return = $dashboard->addToColumn($cell);
+        $this->assertEquals($dashboard, $return);
+        $this->assertEquals([$cell], $dashboard->getColumnChildren(1));
+
+        $expected = [];
+        $this->assertEquals($expected, $dashboard->getColumnChildren(2));
+    }
+}

--- a/tests/TestCase/Dashboard/Module/ActionLinkItemTest.php
+++ b/tests/TestCase/Dashboard/Module/ActionLinkItemTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace CrudView\Test\TestCase\Dashboard;
+
+use Cake\TestSuite\TestCase;
+use CrudView\Dashboard\Module\ActionLinkItem;
+use CrudView\Dashboard\Module\LinkItem;
+
+/**
+ * ActionLinkItemTest class
+ */
+class ActionLinkItemTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $item = new ActionLinkItem('Title', 'https://google.com');
+
+        $expected = 'Title';
+        $this->assertEquals($expected, $item->get('title'));
+
+        $expected = 'https://google.com';
+        $this->assertEquals($expected, $item->get('url'));
+
+        $expected = ['target' => '_blank'];
+        $this->assertEquals($expected, $item->get('options'));
+
+        $expected = [];
+        $this->assertEquals($expected, $item->get('actions'));
+    }
+
+    public function testActions()
+    {
+        $item = new ActionLinkItem('Title', 'https://google.com');
+        $expected = 0;
+        $this->assertCount($expected, $item->get('actions'));
+
+        $linkItem = new LinkItem('Add', ['controller' => 'Posts', 'action' => 'add']);
+        $item = new ActionLinkItem('Posts', ['controller' => 'Posts'], [], [$linkItem]);
+
+        $expected = [$linkItem];
+        $this->assertEquals($expected, $item->get('actions'));
+
+        $actions = $item->get('actions');
+        $expected = ['class' => ['btn btn-default']];
+        $this->assertEquals($expected, $actions[0]->get('options'));
+    }
+}

--- a/tests/TestCase/Dashboard/Module/LinkItemTest.php
+++ b/tests/TestCase/Dashboard/Module/LinkItemTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace CrudView\Test\TestCase\Dashboard;
+
+use Cake\TestSuite\TestCase;
+use CrudView\Dashboard\Module\LinkItem;
+
+/**
+ * LinkItemTest class
+ */
+class LinkItemTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $item = new LinkItem('Title', 'https://google.com');
+
+        $expected = 'Title';
+        $this->assertEquals($expected, $item->get('title'));
+
+        $expected = 'https://google.com';
+        $this->assertEquals($expected, $item->get('url'));
+
+        $expected = ['target' => '_blank'];
+        $this->assertEquals($expected, $item->get('options'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Missing title for LinkItem action
+     */
+    public function testInvalidTitle()
+    {
+        $item = new LinkItem('', null);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid url specified for LinkItem
+     */
+    public function testInvalidNullUrl()
+    {
+        $item = new LinkItem('Title', null);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid url specified for LinkItem
+     */
+    public function testInvalidEmptyUrl()
+    {
+        $item = new LinkItem('Title', '');
+    }
+
+    public function testOptions()
+    {
+        $item = new LinkItem('Title', ['controller' => 'Posts']);
+        $expected = [];
+        $this->assertEquals($expected, $item->get('options'));
+
+        $item = new LinkItem('Title', '/posts');
+        $expected = [];
+        $this->assertEquals($expected, $item->get('options'));
+
+        $item = new LinkItem('Title', 'http://google.com');
+        $expected = ['target' => '_blank'];
+        $this->assertEquals($expected, $item->get('options'));
+
+        $item = new LinkItem('Title', 'https://google.com');
+        $expected = ['target' => '_blank'];
+        $this->assertEquals($expected, $item->get('options'));
+    }
+}

--- a/webroot/css/local.css
+++ b/webroot/css/local.css
@@ -101,3 +101,7 @@ div.actions-wrapper {
 .pagination-container .pagination {
     margin: 0;
 }
+table tr td.actions {
+    white-space: nowrap;
+    width: 1px;
+}


### PR DESCRIPTION
Closes #185 

Example controller:

```
<?php
namespace App\Controller;

use CrudView\Dashboard\Dashboard;
use CrudView\Dashboard\Module\ActionLinkItem;
use CrudView\Dashboard\Module\LinkItem;

class DashboardController extends AppController
{
    public function initialize()
    {
        parent::initialize();

        $this->Crud->mapAction('dashboard', 'CrudView.Dashboard');
    }

    public function dashboard()
    {
        $dashboard = new Dashboard(__('Site Administration'));
        $dashboard->addToColumn($this->cell('CrudView.DashboardTable', [
            'links' => [
                new ActionLinkItem('Posts', ['controller' => 'Posts'], [], [
                    new LinkItem('Add', ['controller' => 'Posts', 'action' => 'add']),
                ]),
            ]
        ]));
        $dashboard->addToColumn($this->cell('CrudView.DashboardTable', [
            'links' => [
                new LinkItem('Facebook', 'https://www.facebook.com'),
                new LinkItem('Instagram', 'https://www.instagram.com'),
                new LinkItem('Patreon', 'https://www.patreon.com'),
            ],
        ]));

        $this->Crud->action()->setConfig('scaffold.dashboard', $dashboard);
        return $this->Crud->execute();
    }
}
```