### PR TITLE
Do not try to format invalid string inputs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofcake/bootstrap-ui": "~1.2"
     },
     "require-dev": {
-        "friendsofcake/cakephp-test-utilities": "dev-master",
+        "friendsofcake/cakephp-test-utilities": "dev-ad-compare-trait",
         "markstory/asset_compress": "^3.2",
         "phpunit/phpunit": "^5.7|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofcake/bootstrap-ui": "~1.2"
     },
     "require-dev": {
-        "friendsofcake/cakephp-test-utilities": "dev-ad-compare-trait",
+        "friendsofcake/cakephp-test-utilities": "^1.0",
         "markstory/asset_compress": "^3.2",
         "phpunit/phpunit": "^5.7|^6.0"
     },

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -52,7 +52,7 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget
             }
         }
 
-        if ($val) {
+        if ($val && !is_string($val)) {
             if ($timezoneAware) {
                 $timestamp = $val->format('U');
                 $dateTimeZone = new DateTimeZone(date_default_timezone_get());

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace CrudView\Test\TestCase\View\Widget;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Form\ContextInterface;
+use Cake\View\StringTemplate;
+use Cake\View\Widget\SelectBoxWidget;
+use CrudView\View\Widget\DateTimeWidget;
+
+/**
+ * DateTimeWidgetTest
+ */
+class DateTimeWidgetTest extends TestCase
+{
+    public function testRenderSimple()
+    {
+        $context = $this->getMockBuilder(ContextInterface::class)->getMock();
+        $templates = new StringTemplate();
+        $selectBox = new SelectBoxWidget($templates);
+        $instance = new DateTimeWidget($templates, $selectBox);
+
+        $expected = [
+            ['div' => true],
+            'input' => [
+                'type',
+                'class',
+                'value',
+                'id',
+                'role',
+                'data-locale',
+                'data-format',
+            ],
+            ['label' => true],
+            'span' => [
+                'class'
+            ],
+            '/label',
+            '/div'
+        ];
+        $result = $instance->render(['id' => 'the-id', 'name' => 'the-name', 'val' => '', 'type' => 'x', 'required' => false], $context);
+        $this->assertHtml($expected, $result);
+    }
+}

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace CrudView\Test\TestCase\View\Widget;
 
+use Cake\I18n\FrozenTime;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;
@@ -56,6 +57,10 @@ class DateTimeWidgetTest extends TestCase
             [
                 'with-string-value.html',
                 ['id' => 'the-id', 'name' => 'the-name', 'val' => '2000-01-01', 'type' => 'x', 'required' => false]
+            ],
+            [
+                'with-date-value.html',
+                ['id' => 'the-id', 'name' => 'the-name', 'val' => (new FrozenTime(strtotime('2000-01-01'))), 'type' => 'x', 'required' => false]
             ]
         ];
     }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -6,12 +6,21 @@ use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\SelectBoxWidget;
 use CrudView\View\Widget\DateTimeWidget;
+use FriendsOfCake\TestUtilities\CompareTrait;
 
 /**
  * DateTimeWidgetTest
  */
 class DateTimeWidgetTest extends TestCase
 {
+    use CompareTrait;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->initComparePath();
+    }
+
     public function testRenderSimple()
     {
         $context = $this->getMockBuilder(ContextInterface::class)->getMock();
@@ -19,25 +28,7 @@ class DateTimeWidgetTest extends TestCase
         $selectBox = new SelectBoxWidget($templates);
         $instance = new DateTimeWidget($templates, $selectBox);
 
-        $expected = [
-            ['div' => true],
-            'input' => [
-                'type',
-                'class',
-                'value',
-                'id',
-                'role',
-                'data-locale',
-                'data-format',
-            ],
-            ['label' => true],
-            'span' => [
-                'class'
-            ],
-            '/label',
-            '/div'
-        ];
         $result = $instance->render(['id' => 'the-id', 'name' => 'the-name', 'val' => '', 'type' => 'x', 'required' => false], $context);
-        $this->assertHtml($expected, $result);
+        $this->assertHtmlSameAsFile('simple.html', $result);
     }
 }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -21,14 +21,42 @@ class DateTimeWidgetTest extends TestCase
         $this->initComparePath();
     }
 
-    public function testRenderSimple()
+    /**
+     * testRender
+     *
+     * @dataProvider renderProvider
+     * @param string $compareFileName
+     * @param array $data
+     */
+    public function testRenderSimple($compareFileName, $data)
     {
         $context = $this->getMockBuilder(ContextInterface::class)->getMock();
         $templates = new StringTemplate();
         $selectBox = new SelectBoxWidget($templates);
         $instance = new DateTimeWidget($templates, $selectBox);
 
-        $result = $instance->render(['id' => 'the-id', 'name' => 'the-name', 'val' => '', 'type' => 'x', 'required' => false], $context);
-        $this->assertHtmlSameAsFile('simple.html', $result);
+        $result = $instance->render($data, $context);
+        $this->assertHtmlSameAsFile($compareFileName, $result);
+    }
+
+    /**
+     * Returns sets of:
+     *  * file name to compare to
+     *  * data for date time widget
+     *
+     * @return array
+     */
+    public function renderProvider()
+    {
+        return [
+            [
+                'simple.html',
+                ['id' => 'the-id', 'name' => 'the-name', 'val' => '', 'type' => 'x', 'required' => false]
+            ],
+            [
+                'with-string-value.html',
+                ['id' => 'the-id', 'name' => 'the-name', 'val' => '2000-01-01', 'type' => 'x', 'required' => false]
+            ]
+        ];
     }
 }

--- a/tests/comparisons/View/Widget/DateTimeWidget/simple.html
+++ b/tests/comparisons/View/Widget/DateTimeWidget/simple.html
@@ -3,7 +3,8 @@
   <input
     type="text"
     class="form-control"
-    name="the-name" value=""
+    name="the-name"
+    value=""
     id="the-id"
     role="datetime-picker"
     data-locale="en_US"

--- a/tests/comparisons/View/Widget/DateTimeWidget/simple.html
+++ b/tests/comparisons/View/Widget/DateTimeWidget/simple.html
@@ -1,0 +1,18 @@
+<div
+  class="input-group x">
+  <input
+    type="text"
+    class="form-control"
+    name="the-name" value=""
+    id="the-id"
+    role="datetime-picker"
+    data-locale="en_US"
+    data-format="L LT" />
+  <label
+    for="the-id"
+    class="input-group-addon">
+    <span
+      class="glyphicon glyphicon-calendar">
+    </span>
+  </label>
+</div>

--- a/tests/comparisons/View/Widget/DateTimeWidget/with-date-value.html
+++ b/tests/comparisons/View/Widget/DateTimeWidget/with-date-value.html
@@ -1,0 +1,19 @@
+<div
+  class="input-group x">
+  <input
+    type="text"
+    class="form-control"
+    name="the-name"
+    value="2000-01-01 00:00:00"
+    id="the-id"
+    role="datetime-picker"
+    data-locale="en_US"
+    data-format="L LT" />
+  <label
+    for="the-id"
+    class="input-group-addon">
+    <span
+      class="glyphicon glyphicon-calendar">
+    </span>
+  </label>
+</div>

--- a/tests/comparisons/View/Widget/DateTimeWidget/with-string-value.html
+++ b/tests/comparisons/View/Widget/DateTimeWidget/with-string-value.html
@@ -1,0 +1,19 @@
+<div
+  class="input-group x">
+  <input
+    type="text"
+    class="form-control"
+    name="the-name"
+    value="2000-01-01"
+    id="the-id"
+    role="datetime-picker"
+    data-locale="en_US"
+    data-format="L LT" />
+  <label
+    for="the-id"
+    class="input-group-addon">
+    <span
+      class="glyphicon glyphicon-calendar">
+    </span>
+  </label>
+</div>


### PR DESCRIPTION
If the input value failed validation, $val is going to be a string

Allow this:

![screenshot from 2018-03-01 11-31-01](https://user-images.githubusercontent.com/33387/36840285-bd1687ae-1d44-11e8-9d6c-bc40db491544.png)


Instead of this:

![screenshot from 2018-03-01 11-35-52](https://user-images.githubusercontent.com/33387/36840292-c657e4e8-1d44-11e8-923c-4312594ba287.png)
