### PR TITLE
Fix action links generation.

### DIFF
--- a/src/Template/Element/actions.ctp
+++ b/src/Template/Element/actions.ctp
@@ -37,24 +37,22 @@ foreach ($actions as $name => $config) {
 
     $url = $config['url'];
     if (!empty($singularVar)) {
-        $setPrimaryKey = false;
-        $modifiedUrl = [];
+        $setPrimaryKey = true;
         foreach ($url as $key => $value) {
-            if (is_array($value)) {
+            if (!is_string($value)) {
                 continue;
             }
 
-            list($k, $v) = str_replace(':primaryKey:', $singularVar->{$primaryKey}, [$key, $value]);
-            if ($key != $k) {
-                $setPrimaryKey = true;
+            if (strpos($value, ':primaryKey:') !== false) {
+                $url[$key] = str_replace(
+                    ':primaryKey:',
+                    $singularVar->{$primaryKey},
+                    $value
+                );
+                $setPrimaryKey = false;
             }
-            if ($value != $v) {
-                $setPrimaryKey = true;
-            }
-            $modifiedUrl[$k] = $v;
         }
-        $url = $modifiedUrl;
-        if (!$setPrimaryKey) {
+        if ($setPrimaryKey) {
             $url[] = $singularVar->{$primaryKey};
         }
     }


### PR DESCRIPTION
- Don't mess with non-string URL array values.
  This fixes `'plugin' => false` being converted to `'plugin' => ''`
- Don't search for :primaryKey: placeholder in URL array keys.
  Can't think of any case where URL key would need primary key value.