### PR TITLE
Don't set label for filter fields by default.

### DIFF
--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -106,7 +106,6 @@ class ViewSearchListener extends BaseListener
 
             $field = $filter->name();
             $input = [
-                'label' => Inflector::humanize(preg_replace('/_id$/', '', $field)),
                 'required' => false,
                 'type' => 'text'
             ];


### PR DESCRIPTION
FormHelper already sets label based on field name in similar manner. Setting label here
actually prevents the translation of labels which FormHelper does.