### PR TITLE
feat: add support for extra left buttons

### DIFF
--- a/docs/_partials/pages/form/submit-buttons.rst
+++ b/docs/_partials/pages/form/submit-buttons.rst
@@ -57,6 +57,38 @@ configuration key as follows:
 Specified values will override the defaults, and will be output in the order
 specified.
 
+Modifying the Default Extra Left Buttons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, extra buttons appear on the right-hand side of forms. The left-hand side
+is managed separately, and will show the following by default
+
+- Delete: An embedded postLink for deleting the current entity. This only appears on the
+  pages that are not rendered via ``AddAction``.
+
+
+To use the defaults, you may either omit the configuration key **or** set it
+to true:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_left_buttons', true);
+
+You can also customize this by using the ``scaffold.form_submit_extra_left_buttons``
+configuration key as follows:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_left_buttons', [
+        [
+            'title' => __d('crud', 'Save & continue editing'),
+            'options' => ['class' => 'btn btn-success btn-save-continue', 'name' => '_edit', 'value' => true],
+            'type' => 'button',
+        ],
+    ]);
+
 Disabling the Default Extra Buttons
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -67,3 +99,13 @@ completely:
 
     $action = $this->Crud->action();
     $action->config('scaffold.form_submit_extra_buttons', false);
+
+Disabling the Default Extra Left Buttons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Disabling the default left extra buttons can also be done in a similar fashion:
+
+.. code-block:: php
+
+    $action = $this->Crud->action();
+    $action->config('scaffold.form_submit_extra_left_buttons', false);

--- a/docs/_partials/pages/form/viewblocks.rst
+++ b/docs/_partials/pages/form/viewblocks.rst
@@ -4,8 +4,8 @@ Available Viewblocks
 The following custom view blocks are available for use within forms:
 
 - ``form.sidebar``: Rendered on the side of a form. Will also change the form
-  width
-- ``form.before_create``: Rendered before ``FormHelper::create()`` is called
-- ``form.after_create``: Rendered after ``FormHelper::create()`` is called
-- ``form.before_end``: Rendered before ``FormHelper::end()`` is called
-- ``form.after_end``: Rendered after ``FormHelper::end()`` is called
+  width.
+- ``form.before_create``: Rendered before ``FormHelper::create()`` is called.
+- ``form.after_create``: Rendered after ``FormHelper::create()`` is called.
+- ``form.before_end``: Rendered before ``FormHelper::end()`` is called.
+- ``form.after_end``: Rendered after ``FormHelper::end()`` is called. Used by embedded ``Form::postLink()`` calls.

--- a/src/Listener/Traits/FormTypeTrait.php
+++ b/src/Listener/Traits/FormTypeTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace CrudView\Listener\Traits;
 
+use Crud\Action\AddAction;
+
 trait FormTypeTrait
 {
     /**
@@ -15,6 +17,7 @@ trait FormTypeTrait
         $controller->set('formEnableDirtyCheck', $this->_getFormEnableDirtyCheck());
         $controller->set('formSubmitButtonText', $this->_getFormSubmitButtonText());
         $controller->set('formSubmitExtraButtons', $this->_getFormSubmitExtraButtons());
+        $controller->set('formSubmitExtraLeftButtons', $this->_getFormSubmitExtraLeftButtons());
         $controller->set('formUrl', $this->_getFormUrl());
     }
 
@@ -64,6 +67,27 @@ trait FormTypeTrait
     }
 
     /**
+     * Get extra form submit left buttons.
+     *
+     * @return bool
+     */
+    protected function _getFormSubmitExtraLeftButtons()
+    {
+        $action = $this->_action();
+        $buttons = $action->getConfig('scaffold.form_submit_extra_left_buttons');
+
+        if ($buttons === false) {
+            return [];
+        }
+
+        if ($buttons === null || $buttons === true) {
+            $buttons = $this->_getDefaultExtraLeftButtons();
+        }
+
+        return $buttons;
+    }
+
+    /**
      * Get default extra buttons
      *
      * @return array
@@ -93,6 +117,34 @@ trait FormTypeTrait
         ];
     }
 
+    /**
+     * Get default extra left buttons
+     *
+     * @return array
+     */
+    protected function _getDefaultExtraLeftButtons()
+    {
+        $buttons = [];
+
+        $action = $this->_action();
+        if (!($action instanceof AddAction)) {
+            $buttons[] = [
+                'title' => __d('crud', 'Delete'),
+                'url' => ['action' => 'delete'],
+                'options' => [
+                    'block' => 'form.after_end',
+                    'class' => 'btn btn-danger btn-delete',
+                    'confirm' => __d('crud', 'Are you sure you want to delete this record?'),
+                    'name' => '_delete',
+                    'style' => 'margin-left: 0',
+                ],
+                'type' => 'postLink',
+                '_label' => 'delete',
+            ];
+        }
+
+        return $buttons;
+    }
     /**
      * Get form url.
      *

--- a/src/Template/Element/form/buttons.ctp
+++ b/src/Template/Element/form/buttons.ctp
@@ -1,3 +1,24 @@
+<?php if ($formSubmitExtraLeftButtons) : ?>
+<div class="col pull-left">
+    <?php
+    if (!empty($formSubmitExtraLeftButtons)) {
+        foreach ($formSubmitExtraLeftButtons as $button) {
+            if ($button['type'] === 'button') {
+                echo $this->Form->button($button['title'], $button['options']);
+            } elseif ($button['type'] === 'link') {
+                echo $this->Html->link($button['title'], $button['url'], $button['options']);
+            } elseif ($button['type'] === 'postLink') {
+                if (is_array($button['url'])) {
+                    $button['url'][] = $$viewVar->get($primaryKey);
+                }
+                echo $this->Form->postLink($button['title'], $button['url'], $button['options']);
+            }
+        }
+    }
+    ?>
+</div>
+<?php endif ?>
+
 <div class="col pull-right">
     <?= $this->Form->button(
         $formSubmitButtonText,


### PR DESCRIPTION
This will show a delete button by default on the left-hand side of non-AddAction pages.

Closes #186