### PR TITLE
sidebar-navigation.rst: Fix tablesBlacklist key

### DIFF
--- a/docs/general-configuration/sidebar-navigation.rst
+++ b/docs/general-configuration/sidebar-navigation.rst
@@ -32,12 +32,12 @@ the ``scaffold.tables_blacklist`` configuration key to specify tables to
         'users',
     ]);
 
-You can also specify a global tables blacklist by setting ``Crud.tablesBlacklist``
+You can also specify a global tables blacklist by setting ``CrudView.tablesBlacklist``
 configuration key. By default the ``phinxlog`` table is blacklisted.
 
 .. code-block:: php
 
-    Configure::write('Crud.tablesBlacklist', ['phinxlog']);
+    Configure::write('CrudView.tablesBlacklist', ['phinxlog']);
 
 
 Disabling the Sidebar Navigation


### PR DESCRIPTION
By the way I'm not sure if the current behavior of `CrudViewConfigTrait` is intended. Once I add a `CrudView` key to my configuration (e.g. just `CrudView.tablesBlacklist`), all default options (including JS/CSS) go away:
https://github.com/FriendsOfCake/crud-view/blob/8903b77738723fdb6cb27c99d5c96a9592022a54/src/Traits/CrudViewConfigTrait.php#L18-L20