### PR TITLE
Fix issue #280

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -554,7 +554,7 @@ class ViewListener extends BaseListener
 
         $keys = $associations->keys();
         if (!empty($whitelist)) {
-            $keys = array_intersect($keys, array_map('strtolower', $whitelist));
+            $keys = array_intersect($keys, $whitelist);
         }
         foreach ($keys as $associationName) {
             /** @var \Cake\ORM\Association $association */


### PR DESCRIPTION
The associations are inflected tabelized, not lowercased.
This is a prerequesite and doesn't need to be inflected here: $action->setConfig('scaffold.relations', ['users']); in a Controller throws an exception, 'Users' works.