### PR TITLE
Fix using default relations

### DIFF
--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -68,7 +68,7 @@ class ViewListener extends BaseListener
         }
 
         if (!$event->getSubject()->query->getContain()) {
-            $event->getSubject()->query->contain($this->_getRelatedModels(['manyToOne', 'oneToOne']));
+            $event->getSubject()->query->contain($this->_getRelatedModels(['belongsTo', 'hasOne']));
         }
     }
 


### PR DESCRIPTION
When using the default configuration, related fields are displayed as ids. That is, they're not contained in the paginate query. The docs say the paginate query should automatically contain BelongsTo and HasOne associations but it doesn't.

With this change it works.