### PR TITLE
Added array return type to _getSidebarNavigation()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ permissions:
 
 jobs:
   testsuite:
-    uses: cakephp/.github/.github/workflows/testsuite-without-db.yml@5.x
-    secrets: inherit
+    uses: ADmad/.github/.github/workflows/testsuite-with-db.yml@master
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   cs-stan:
     uses: ADmad/.github/.github/workflows/cs-stan.yml@master
-    secrets: inherit

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "friendsofcake/cakephp-test-utilities": "^3.0",
         "markstory/asset_compress": "^5.0",
-        "phpunit/phpunit": "^10.1 || ^11.0"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "cakephp/cakephp": "^5.0",
         "friendsofcake/crud": "^7.0",
-        "friendsofcake/bootstrap-ui": "^5.0"
+        "friendsofcake/bootstrap-ui": "^5.1"
     },
     "require-dev": {
         "friendsofcake/cakephp-test-utilities": "^3.0",

--- a/config/asset_compress.ini
+++ b/config/asset_compress.ini
@@ -10,7 +10,7 @@ files[]=https://cdn.jsdelivr.net/npm/jquery@3.7/dist/jquery.min.js
 files[]=https://cdn.jsdelivr.net/npm/bootstrap@5.3/dist/js/bootstrap.bundle.min.js
 files[]=https://cdn.jsdelivr.net/npm/flatpickr@4.6
 files[]=https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js
-files[]=https://cdn.jsdelivr.net/npm/jquery.dirtyforms@2.0/jquery.dirtyforms.min.js
+files[]=https://cdn.jsdelivr.net/npm/jquery.dirtyforms@2.0
 
 [crudview.js]
 files[]=plugin:CrudView:js/local.js

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,37 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Cannot unset offset mixed on array\\{\\}\\.$#"
+			message: '#^Trait CrudView\\Listener\\Traits\\DeprecatedConfigurationKeyTrait is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Listener/Traits/DeprecatedConfigurationKeyTrait.php
+
+		-
+			message: '#^Cannot unset offset mixed on array\{\}\.$#'
+			identifier: unset.offset
 			count: 2
 			path: src/Listener/ViewListener.php
 
 		-
-			message: "#^Offset \\(int\\|string\\) on array\\{\\} in isset\\(\\) does not exist\\.$#"
+			message: '#^Offset \(int\|string\) on array\{\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
 			count: 2
 			path: src/Listener/ViewListener.php
 
 		-
-			message: "#^Parameter \\#1 \\$field of method CrudView\\\\Listener\\\\ViewListener\\:\\:_deriveFieldFromContext\\(\\) expects string, array\\<int, string\\>\\|string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$field of method CrudView\\Listener\\ViewListener\:\:_deriveFieldFromContext\(\) expects string, list\<string\>\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Listener/ViewListener.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
+			message: '#^Result of \|\| is always false\.$#'
+			identifier: booleanOr.alwaysFalse
 			count: 1
 			path: src/Listener/ViewListener.php
 
 		-
-			message: "#^Call to an undefined method Cake\\\\ORM\\\\Table\\:\\:searchManager\\(\\)\\.$#"
+			message: '#^Call to an undefined method Cake\\ORM\\Table\:\:searchManager\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Listener/ViewSearchListener.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,7 +19,7 @@ parameters:
 			path: src/Listener/ViewListener.php
 
 		-
-			message: '#^Parameter \#1 \$field of method CrudView\\Listener\\ViewListener\:\:_deriveFieldFromContext\(\) expects string, list\<string\>\|string\|null given\.$#'
+			message: '#^Parameter \#1 \$field of method CrudView\\Listener\\ViewListener\:\:_deriveFieldFromContext\(\) expects string, array\<string\>\|string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Listener/ViewListener.php

--- a/src/Breadcrumb/ActiveBreadcrumb.php
+++ b/src/Breadcrumb/ActiveBreadcrumb.php
@@ -9,7 +9,6 @@ class ActiveBreadcrumb extends Breadcrumb
     /**
      * // phpcs:ignore
      * @inheritDoc
-     * @psalm-suppress MissingParamType
      */
     public function __construct(string|array $title, string|array|null $url = null, array $options = [])
     {

--- a/src/Listener/Traits/SidebarNavigationTrait.php
+++ b/src/Listener/Traits/SidebarNavigationTrait.php
@@ -24,9 +24,9 @@ trait SidebarNavigationTrait
     /**
      * Returns the sidebar navigation to show on scaffolded view
      *
-     * @return string|false|null
+     * @return array|string|false|null
      */
-    protected function _getSidebarNavigation(): string|false|null
+    protected function _getSidebarNavigation(): array|string|false|null
     {
         $action = $this->_action();
 

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -229,7 +229,7 @@ class ViewListener extends BaseListener
                 foreach ($associationTypes as $assocType) {
                     $associations = array_merge(
                         $associations,
-                        $this->_model()->associations()->getByType($assocType)
+                        $this->_model()->associations()->getByType($assocType),
                     );
                 }
             }
@@ -273,7 +273,7 @@ class ViewListener extends BaseListener
         $data = [
             'modelClass' => $modelClass,
             'singularHumanName' => Inflector::humanize(
-                Inflector::underscore(Inflector::singularize($modelClass))
+                Inflector::underscore(Inflector::singularize($modelClass)),
             ),
             'pluralHumanName' => Inflector::humanize(Inflector::underscore($controller->getName())),
             'singularVar' => Inflector::singularize($controller->getName()),
@@ -310,7 +310,7 @@ class ViewListener extends BaseListener
         $action = $this->_action();
         $scaffoldFields = Hash::normalize(
             (array)$action->getConfig('scaffold.fields'),
-            default: []
+            default: [],
         );
 
         if (empty($scaffoldFields) || $action->getConfig('scaffold.autoFields')) {
@@ -342,7 +342,7 @@ class ViewListener extends BaseListener
 
         $fieldSettings = Hash::normalize(
             (array)$action->getConfig('scaffold.field_settings'),
-            default: []
+            default: [],
         );
         $fieldSettings = array_intersect_key($fieldSettings, $scaffoldFields);
         $scaffoldFields = Hash::merge($scaffoldFields, $fieldSettings);
@@ -467,7 +467,7 @@ class ViewListener extends BaseListener
             'method' => $method,
             'options' => array_diff_key(
                 $config,
-                array_flip(['method', 'scope', 'link_title', 'url', 'scaffold', 'callback'])
+                array_flip(['method', 'scope', 'link_title', 'url', 'scaffold', 'callback']),
             ),
         ];
         if (!empty($config['callback'])) {
@@ -493,7 +493,7 @@ class ViewListener extends BaseListener
 
         $allActions = array_merge(
             Hash::normalize($actions, default: []),
-            Hash::normalize($extraActions, default: [])
+            Hash::normalize($extraActions, default: []),
         );
 
         $blacklist = (array)$this->_action()->getConfig('scaffold.actions_blacklist');
@@ -547,13 +547,13 @@ class ViewListener extends BaseListener
             $associationConfiguration[$type][$assocKey]['plugin'] = pluginSplit($association->getClassName())[0];
             $associationConfiguration[$type][$assocKey]['controller'] = $assocKey;
             $associationConfiguration[$type][$assocKey]['entity'] = Inflector::singularize(
-                Inflector::underscore($assocKey)
+                Inflector::underscore($assocKey),
             );
             $associationConfiguration[$type][$assocKey]['entities'] = Inflector::underscore($assocKey);
 
             $associationConfiguration[$type][$assocKey] = array_merge(
                 $associationConfiguration[$type][$assocKey],
-                $this->_action()->getConfig('association.' . $assocKey) ?: []
+                $this->_action()->getConfig('association.' . $assocKey) ?: [],
             );
         }
 

--- a/src/Listener/ViewListener.php
+++ b/src/Listener/ViewListener.php
@@ -42,7 +42,7 @@ class ViewListener extends BaseListener
      *
      * @param \Cake\Event\EventInterface $event Event.
      * @return void
-     * @psalm-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
+     * @phpstan-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
      */
     public function beforeFind(EventInterface $event): void
     {
@@ -63,7 +63,7 @@ class ViewListener extends BaseListener
      *
      * @param \Cake\Event\EventInterface $event Event.
      * @return void
-     * @psalm-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
+     * @phpstan-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
      */
     public function beforePaginate(EventInterface $event): void
     {
@@ -84,7 +84,7 @@ class ViewListener extends BaseListener
      *
      * @param \Cake\Event\EventInterface $event Event.
      * @return void
-     * @psalm-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
+     * @phpstan-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
      */
     public function beforeRender(EventInterface $event): void
     {
@@ -96,7 +96,6 @@ class ViewListener extends BaseListener
             $this->_entity = $event->getSubject()->entity;
         }
 
-        /** @psalm-suppress RedundantPropertyInitializationCheck */
         if (!isset($this->associations)) {
             $this->associations = $this->_associations(array_keys($this->_getRelatedModels()));
         }
@@ -134,12 +133,11 @@ class ViewListener extends BaseListener
      *
      * @param \Cake\Event\EventInterface $event Event.
      * @return void
-     * @psalm-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
+     * @phpstan-param \Cake\Event\EventInterface<\Crud\Event\Subject> $event
      */
     public function setFlash(EventInterface $event): void
     {
         unset($event->getSubject()->params['class']);
-        /** @psalm-suppress UndefinedPropertyAssignment */
         $event->getSubject()->element = ltrim($event->getSubject()->type);
     }
 
@@ -181,11 +179,11 @@ class ViewListener extends BaseListener
             $displayFieldValue === null
             || $this->_model()->getDisplayField() === $this->_model()->getPrimaryKey()
         ) {
-            /** @psalm-var string $primaryKeyValue */
+            /** @phpstan-var string $primaryKeyValue */
             return sprintf('%s %s #%s', $actionName, $controllerName, $primaryKeyValue);
         }
 
-        /** @psalm-var string $primaryKeyValue */
+        /** @phpstan-var string $primaryKeyValue */
         return sprintf('%s %s #%s: %s', $actionName, $controllerName, $primaryKeyValue, $displayFieldValue);
     }
 
@@ -410,9 +408,7 @@ class ViewListener extends BaseListener
         }
 
         foreach ($actionBlacklist as $actionName) {
-            /** @psalm-suppress EmptyArrayAccess */
             unset($table[$actionName]);
-            /** @psalm-suppress EmptyArrayAccess */
             unset($entity[$actionName]);
         }
 
@@ -440,7 +436,6 @@ class ViewListener extends BaseListener
         if ($this->_crud()->isActionMapped($realAction)) {
             $action = $this->_action($realAction);
             $class = get_class($action);
-            /** @psalm-suppress PossiblyFalseOperand */
             $class = substr($class, strrpos($class, '\\') + 1);
 
             if ($class === 'DeleteAction') {
@@ -591,7 +586,6 @@ class ViewListener extends BaseListener
      */
     protected function _displayFieldValue(): string|int|null
     {
-        /** @psalm-suppress PossiblyInvalidArgument */
         return $this->_deriveFieldFromContext($this->_model()->getDisplayField());
     }
 

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -144,7 +144,6 @@ class ViewSearchListener extends BaseListener
                 $input['class'] = 'autocomplete';
             }
 
-            /** @psalm-suppress PossiblyUndefinedArrayOffset */
             if (
                 !empty($input['class'])
                 && strpos($input['class'], 'autocomplete') !== false
@@ -156,7 +155,6 @@ class ViewSearchListener extends BaseListener
                     $input['options'][$input['value']] = $input['value'];
                 }
 
-                /** @psalm-suppress PossiblyInvalidOperand */
                 $input += [
                     'data-input-type' => 'text',
                     'data-tags' => 'true',

--- a/src/Listener/ViewSearchListener.php
+++ b/src/Listener/ViewSearchListener.php
@@ -123,6 +123,9 @@ class ViewSearchListener extends BaseListener
             if (!isset($input['options']) && $schema->getColumnType($field) === 'boolean') {
                 $input['options'] = [1 => __d('crud', 'Yes'), 0 => __d('crud', 'No')];
                 $input['type'] = 'select';
+                if ($config['select2']) {
+                    $input['class'] = 'no-select2';
+                }
             }
 
             if (isset($input['options'])) {
@@ -137,7 +140,7 @@ class ViewSearchListener extends BaseListener
                 continue;
             }
 
-            if ($input['type'] === 'select' && empty($input['class']) && $config['autocomplete']) {
+            if ($input['type'] === 'select' && $config['autocomplete'] && empty($input['class'])) {
                 $input['class'] = 'autocomplete';
             }
 
@@ -158,7 +161,7 @@ class ViewSearchListener extends BaseListener
                     'data-input-type' => 'text',
                     'data-tags' => 'true',
                     'data-allow-clear' => 'true',
-                    'data-placeholder' => '',
+                    'data-placeholder' => $this->getPlaceholder($field),
                 ];
             }
 
@@ -167,6 +170,9 @@ class ViewSearchListener extends BaseListener
             }
             if ($input['type'] === 'select') {
                 $input['empty'] ??= $this->getPlaceholder($field);
+                if ($config['select2']) {
+                    $input['data-placeholder'] ??= $this->getPlaceholder($field);
+                }
             }
 
             if (

--- a/src/View/Cell/TablesListCell.php
+++ b/src/View/Cell/TablesListCell.php
@@ -25,7 +25,6 @@ class TablesListCell extends Cell
             $tables = $schema->listTables();
             sort($tables);
 
-            /** @psalm-suppress RiskyTruthyFalsyComparison */
             if (!empty($blacklist)) {
                 $tables = array_diff($tables, $blacklist);
             }

--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -155,7 +155,6 @@ class CrudViewHelper extends Helper
 
         $fieldFormatters = $this->getConfig('fieldFormatters');
         if (isset($fieldFormatters[$type])) {
-            /** @psalm-suppress PossiblyNullArrayOffset */
             if (is_callable($fieldFormatters[$type])) {
                 return $fieldFormatters[$type](
                     $field,
@@ -166,7 +165,6 @@ class CrudViewHelper extends Helper
                 );
             }
 
-            /** @psalm-suppress PossiblyNullArrayOffset */
             return $this->{$fieldFormatters[$type]}($field, $value, $options);
         }
 

--- a/src/View/Helper/CrudViewHelper.php
+++ b/src/View/Helper/CrudViewHelper.php
@@ -401,7 +401,7 @@ class CrudViewHelper extends Helper
                     '_redirect_url' => $this->getView()->getRequest()->getUri()->getPath(),
                 ],
             ],
-            $options
+            $options,
         );
     }
 
@@ -420,7 +420,7 @@ class CrudViewHelper extends Helper
         return $this->Html->link(
             $title,
             ['action' => 'view', $entity->get($this->getViewVar('primaryKey'))],
-            $options
+            $options,
         );
     }
 
@@ -497,8 +497,8 @@ class CrudViewHelper extends Helper
                     sprintf('scaffold-%s-%s', $pluralVar, $action),
                 ],
                 $args,
-                $viewClasses
-            ))
+                $viewClasses,
+            )),
         );
     }
 }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -111,7 +111,6 @@ class DateTimeWidget extends BUIDateTimeWidget
 
         $clearIcon = $this->clearIcon;
         $toggleIcon = $this->calendarIcon;
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
         if (isset($datetimePicker['iconClass'])) {
             $toggleIcon = $datetimePicker['iconClass'];
             unset($datetimePicker['iconClass']);
@@ -155,7 +154,6 @@ class DateTimeWidget extends BUIDateTimeWidget
             return $input;
         }
 
-        /** @psalm-suppress PossiblyInvalidArrayOffset */
         return $this->_templates->format('datetimePicker', [
             'input' => $input,
             'toggleIcon' => $toggleIcon,

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -95,7 +95,7 @@ class DateTimeWidget extends BUIDateTimeWidget
         // This is the format that will be display to user
         if (isset($datetimePicker['data-alt-format'])) {
             $datetimePicker['data-alt-format'] = $this->convertPHPToDatePickerFormat(
-                $datetimePicker['data-alt-format']
+                $datetimePicker['data-alt-format'],
             );
             $datetimePicker['data-alt-input'] = 'true';
         }
@@ -147,7 +147,7 @@ class DateTimeWidget extends BUIDateTimeWidget
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $data,
-                ['name', 'type']
+                ['name', 'type'],
             ),
         ]);
 
@@ -163,7 +163,7 @@ class DateTimeWidget extends BUIDateTimeWidget
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $datetimePicker,
-                ['toggleIcon', 'clearIcon']
+                ['toggleIcon', 'clearIcon'],
             ),
         ]);
     }

--- a/templates/element/action-groups.php
+++ b/templates/element/action-groups.php
@@ -15,6 +15,17 @@ foreach ($groups as $key => $group) {
 ?>
 
 <?php foreach ($groups as $key => $group) : ?>
+    <?php
+    if (count($group) === 1) {
+        $subaction = key($group);
+        if (is_numeric($subaction)) {
+            $subaction = $group[$subaction];
+        }
+
+        echo $this->element('action-button', ['config' => $links[$subaction]]);
+        continue;
+    }
+    ?>
     <div class='btn-group' role="group">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
             <?= $key ?>

--- a/templates/element/search.php
+++ b/templates/element/search.php
@@ -4,22 +4,23 @@ if (empty($searchInputs)) {
 }
 ?>
 
-<div class="search-filters">
+<div class="search-filters mb-3">
     <?php
     $searchOptions = $searchOptions ?? [];
     $searchOptions += ['align' => 'inline', 'id' => 'searchFilter'];
-
-    echo $this->Form->create(null, $searchOptions);
-    echo $this->Form->hidden('_search');
     ?>
 
+    <?= $this->Form->create(null, $searchOptions) ?>
+    <?= $this->Form->hidden('_search') ?>
+
     <?= $this->Form->controls($searchInputs, ['fieldset' => false]); ?>
-    <?= $this->Form->button(__d('crud', 'Filter results'), ['type' => 'submit', 'class' => 'btn btn-primary']); ?>
-    <?php if ($this->Search->isSearch()) : ?>
-        <div class="col-auto">
-            <?= $this->Search->resetLink(__d('crud', 'Reset'), ['class' => 'btn btn-primary']) ?>
-        </div>
-    <?php endif ?>
+
+    <div class="col-auto">
+        <?= $this->Form->button(__d('crud', 'Filter results'), ['type' => 'submit', 'class' => 'btn btn-primary']); ?>
+        <?php if ($this->Search->isSearch()) : ?>
+            <?= $this->Search->resetLink(__d('crud', 'Reset'), ['class' => 'btn btn-secondary']) ?>
+        <?php endif ?>
+    </div>
 
     <?= $this->Form->end(); ?>
 </div>

--- a/tests/TestCase/Listener/ViewSearchListenerTest.php
+++ b/tests/TestCase/Listener/ViewSearchListenerTest.php
@@ -73,7 +73,7 @@ class ViewSearchListenerTest extends TestCase
                 'data-input-type' => 'text',
                 'data-tags' => 'true',
                 'data-allow-clear' => 'true',
-                'data-placeholder' => '',
+                'data-placeholder' => 'Auto',
                 'empty' => 'Auto',
                 'data-url' => '/blogs/lookup.json?id=auto&value=auto',
             ],
@@ -82,6 +82,7 @@ class ViewSearchListenerTest extends TestCase
                 'type' => 'select',
                 'value' => null,
                 'options' => [1 => 'Yes', 0 => 'No'],
+                'class' => 'no-select2',
                 'empty' => 'Is Active',
             ],
             'user_id' => [
@@ -90,6 +91,7 @@ class ViewSearchListenerTest extends TestCase
                 'value' => null,
                 'class' => 'autocomplete',
                 'empty' => 'User',
+                'data-placeholder' => 'User',
                 'data-url' => '/blogs/lookup.json?id=user_id&value=user_id',
             ],
             'custom_select' => [
@@ -98,6 +100,7 @@ class ViewSearchListenerTest extends TestCase
                 'required' => false,
                 'value' => null,
                 'class' => 'autocomplete',
+                'data-placeholder' => 'Custom Select',
                 'data-url' => '/blogs/lookup.json?id=custom_select&value=custom_select',
             ],
         ];
@@ -126,6 +129,7 @@ class ViewSearchListenerTest extends TestCase
                 'type' => 'select',
                 'value' => null,
                 'empty' => 'User',
+                'data-placeholder' => 'User',
             ],
             'custom_select' => [
                 'empty' => false,
@@ -133,6 +137,7 @@ class ViewSearchListenerTest extends TestCase
                 'class' => 'autocomplete',
                 'required' => false,
                 'value' => null,
+                'data-placeholder' => 'Custom Select',
                 'data-url' => '/blogs/lookup.json?id=custom_select&value=custom_select',
             ],
         ];

--- a/tests/TestCase/View/CrudViewTest.php
+++ b/tests/TestCase/View/CrudViewTest.php
@@ -24,7 +24,7 @@ class CrudViewTest extends TestCase
                         'fieldFormatters' => ['datetime' => 'formatTime'],
                     ],
                 ],
-            ]
+            ],
         );
 
         $expected = [

--- a/tests/TestCase/View/Helper/CrudViewHelperTest.php
+++ b/tests/TestCase/View/Helper/CrudViewHelperTest.php
@@ -76,7 +76,7 @@ class CrudViewHelperTest extends TestCase
 
         $this->assertSame(
             '1/15/00',
-            $this->CrudView->process('user.birth_date', $entity)
+            $this->CrudView->process('user.birth_date', $entity),
         );
     }
 

--- a/tests/TestCase/View/Helper/CrudViewHelperTest.php
+++ b/tests/TestCase/View/Helper/CrudViewHelperTest.php
@@ -54,10 +54,10 @@ class CrudViewHelperTest extends TestCase
         $this->assertEquals($entity->created->i18nFormat(), $result);
 
         $result = $this->CrudView->introspect('created', 'invalid');
-        $this->assertEquals('<span class="bg-info badge">N/A</span>', $result);
+        $this->assertEquals('<span class="text-bg-info badge">N/A</span>', $result);
 
         $result = $this->CrudView->introspect('created', null);
-        $this->assertEquals('<span class="bg-info badge">N/A</span>', $result);
+        $this->assertEquals('<span class="text-bg-info badge">N/A</span>', $result);
 
         $this->CrudView->setConfig('fieldFormatters', [
             'datetime' => function () {

--- a/webroot/js/local.js
+++ b/webroot/js/local.js
@@ -14,7 +14,9 @@ var CrudView = {
     },
 
     flatpickr: function (selector) {
-        $(selector).flatpickr();
+        if ($.flatpickr) {
+            $(selector).flatpickr();
+        }
     },
 
     select2: function (selector) {
@@ -78,8 +80,10 @@ var CrudView = {
     },
 
     dirtyForms: function () {
-        $.DirtyForms.dialog = false;
-        $('form[data-dirty-check=1]').dirtyForms();
+        if ($.DirtyForms) {
+            $.DirtyForms.dialog = false;
+            $('form[data-dirty-check=1]').dirtyForms();
+        }
     },
 
     dropdown: function () {


### PR DESCRIPTION
Custom menu configuration can accept an array: https://crud-view.readthedocs.io/en/latest/general-configuration/sidebar-navigation.html 

Added array return type for _getSidebarNavigation solves invalid return type error when using config array.